### PR TITLE
Add AI rule analysis modals and simplify dashboard viewer

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -55,6 +55,7 @@ import DatasourceManagementPage from './pages/resources/DatasourceManagementPage
 import AutoDiscoveryPage from './pages/resources/AutoDiscoveryPage';
 import ResourceOverviewPage from './pages/resources/ResourceOverviewPage';
 import LicensePage from './pages/settings/platform/LicensePage';
+import { ThemeProvider } from './contexts/ThemeContext';
 
 // Lucide icons renderer
 const RenderIcons = () => {
@@ -225,7 +226,9 @@ const App: React.FC = () => {
             <OptionsProvider>
                 <PageMetadataProvider>
                     <ContentProvider>
-                        <AppRoutes />
+                        <ThemeProvider>
+                            <AppRoutes />
+                        </ThemeProvider>
                     </ContentProvider>
                 </PageMetadataProvider>
             </OptionsProvider>

--- a/components/DashboardViewer.tsx
+++ b/components/DashboardViewer.tsx
@@ -1,8 +1,6 @@
 import React, { useState, useMemo, useEffect } from 'react';
 import { Dashboard } from '../types';
 import Dropdown from './Dropdown';
-import Icon from './Icon';
-import PlaceholderModal from './PlaceholderModal';
 import { useOptions } from '../contexts/OptionsContext';
 import { useContent } from '../contexts/ContentContext';
 
@@ -21,9 +19,6 @@ const DashboardViewer: React.FC<DashboardViewerProps> = ({ dashboard }) => {
     const [refresh, setRefresh] = useState('');
     const [timeRange, setTimeRange] = useState('from=now-6h&to=now');
     
-    const [isPlaceholderModalOpen, setIsPlaceholderModalOpen] = useState(false);
-    const [modalFeatureName, setModalFeatureName] = useState('');
-
     useEffect(() => {
         if (grafanaOptions) {
             if (grafanaOptions.refreshOptions.length > 0) {
@@ -38,11 +33,6 @@ const DashboardViewer: React.FC<DashboardViewerProps> = ({ dashboard }) => {
             }
         }
     }, [grafanaOptions]);
-
-    const showPlaceholderModal = (featureName: string) => {
-        setModalFeatureName(featureName);
-        setIsPlaceholderModalOpen(true);
-    };
 
     const embedUrl = useMemo(() => {
         if (!dashboard.grafanaUrl) return '';
@@ -90,10 +80,6 @@ const DashboardViewer: React.FC<DashboardViewerProps> = ({ dashboard }) => {
                         </div>
                         <div className="flex items-center space-x-4">
                             <Dropdown label={grafanaOptions.timeLabel} options={grafanaOptions.timeOptions || []} value={timeRange} onChange={setTimeRange} minWidth="w-40" />
-                            <div className="flex items-center space-x-1">
-                                <button onClick={() => showPlaceholderModal(pageContent.ZOOM_IN)} className="p-2 rounded-md hover:bg-slate-700/50"><Icon name="zoom-in" className="w-5 h-5" /></button>
-                                <button onClick={() => showPlaceholderModal(pageContent.SHARE_DASHBOARD)} className="p-2 rounded-md hover:bg-slate-700/50"><Icon name="share-2" className="w-5 h-5" /></button>
-                            </div>
                         </div>
                     </>
                 )}
@@ -105,11 +91,6 @@ const DashboardViewer: React.FC<DashboardViewerProps> = ({ dashboard }) => {
                     <div className="flex items-center justify-center h-full"><p className="text-slate-400">{pageContent.GRAFANA_URL_NOT_CONFIGURED}</p></div>
                 )}
             </div>
-             <PlaceholderModal
-                isOpen={isPlaceholderModalOpen}
-                onClose={() => setIsPlaceholderModalOpen(false)}
-                featureName={modalFeatureName}
-            />
         </div>
     );
 };

--- a/components/NewIncidentModal.tsx
+++ b/components/NewIncidentModal.tsx
@@ -1,0 +1,256 @@
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import Modal from './Modal';
+import { useOptions } from '../contexts/OptionsContext';
+import { useContent } from '../contexts/ContentContext';
+import api from '../services/api';
+import { AlertRule, Incident, IncidentCreateRequest, Resource } from '../types';
+import { showToast } from '../services/toast';
+import Icon from './Icon';
+
+interface NewIncidentModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onSuccess?: (incident: Incident) => void;
+}
+
+type FormState = IncidentCreateRequest & { assignee?: string };
+
+const DEFAULT_PRIORITY: Incident['priority'] = 'P2';
+const DEFAULT_SEVERITY: Incident['severity'] = 'warning';
+const DEFAULT_SERVICE_IMPACT: Incident['serviceImpact'] = 'Medium';
+
+const NewIncidentModal: React.FC<NewIncidentModalProps> = ({ isOpen, onClose, onSuccess }) => {
+  const { options } = useOptions();
+  const { content } = useContent();
+  const globalContent = content?.GLOBAL;
+
+  const incidentOptions = options?.incidents;
+  const [resources, setResources] = useState<Resource[]>([]);
+  const [rules, setRules] = useState<AlertRule[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const getInitialForm = useCallback((): FormState => ({
+    summary: '',
+    resourceId: '',
+    ruleId: '',
+    severity: incidentOptions?.severities?.[0]?.value ?? DEFAULT_SEVERITY,
+    serviceImpact: incidentOptions?.serviceImpacts?.[0]?.value ?? DEFAULT_SERVICE_IMPACT,
+    priority: incidentOptions?.priorities?.[0]?.value ?? DEFAULT_PRIORITY,
+    assignee: '',
+  }), [incidentOptions]);
+
+  const [form, setForm] = useState<FormState>(getInitialForm);
+
+  useEffect(() => {
+    if (!isOpen) {
+      setForm(getInitialForm());
+      setResources([]);
+      setRules([]);
+      setError(null);
+      return;
+    }
+
+    const fetchFormData = async () => {
+      setIsLoading(true);
+      setError(null);
+      try {
+        const [resourceRes, rulesRes] = await Promise.all([
+          api.get<{ items: Resource[] }>('/resources', { params: { page: 1, page_size: 100 } }),
+          api.get<AlertRule[]>('/incidents/alert-rules'),
+        ]);
+        setResources(resourceRes.data.items);
+        setRules(rulesRes.data);
+
+        setForm(prev => ({
+          ...prev,
+          resourceId: prev.resourceId || resourceRes.data.items[0]?.id || '',
+          ruleId: prev.ruleId || rulesRes.data[0]?.id || '',
+        }));
+      } catch (err) {
+        console.error('Failed to load incident creation data', err);
+        setError('無法載入事件建立所需資料。');
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    fetchFormData();
+  }, [isOpen, getInitialForm]);
+
+  useEffect(() => {
+    setForm(prev => ({
+      ...prev,
+      severity: prev.severity || incidentOptions?.severities?.[0]?.value || DEFAULT_SEVERITY,
+      serviceImpact: prev.serviceImpact || incidentOptions?.serviceImpacts?.[0]?.value || DEFAULT_SERVICE_IMPACT,
+      priority: prev.priority || incidentOptions?.priorities?.[0]?.value || DEFAULT_PRIORITY,
+    }));
+  }, [incidentOptions]);
+
+  const handleInputChange = useCallback(<K extends keyof FormState>(key: K, value: FormState[K]) => {
+    setForm(prev => ({ ...prev, [key]: value }));
+  }, []);
+
+  const canSubmit = useMemo(() => {
+    return Boolean(form.summary && form.resourceId && form.ruleId && form.severity && form.serviceImpact);
+  }, [form]);
+
+  const handleSubmit = useCallback(async (event: React.FormEvent) => {
+    event.preventDefault();
+    if (!canSubmit) {
+      return;
+    }
+    setIsSubmitting(true);
+    try {
+      const payload: IncidentCreateRequest = {
+        summary: form.summary,
+        resourceId: form.resourceId,
+        ruleId: form.ruleId,
+        severity: form.severity,
+        serviceImpact: form.serviceImpact,
+        priority: form.priority ? form.priority : undefined,
+        assignee: form.assignee?.trim() ? form.assignee.trim() : undefined,
+      };
+      const { data } = await api.post<Incident>('/incidents', payload);
+      showToast(`事件「${data.summary}」已建立。`, 'success');
+      onSuccess?.(data);
+      onClose();
+    } catch (err) {
+      console.error('Failed to create incident', err);
+      showToast('無法建立事件，請稍後再試。', 'error');
+    } finally {
+      setIsSubmitting(false);
+    }
+  }, [form, canSubmit, onClose, onSuccess]);
+
+  return (
+    <Modal
+      title="新增事件"
+      isOpen={isOpen}
+      onClose={onClose}
+      width="w-2/5 max-w-2xl"
+      footer={(
+        <div className="flex gap-3">
+          <button
+            type="button"
+            onClick={onClose}
+            className="px-4 py-2 rounded-md border border-slate-600 text-slate-200 hover:bg-slate-700/70"
+            disabled={isSubmitting}
+          >
+            {globalContent?.CANCEL || '取消'}
+          </button>
+          <button
+            type="submit"
+            form="new-incident-form"
+            className={`px-4 py-2 rounded-md text-white ${canSubmit && !isSubmitting ? 'bg-sky-600 hover:bg-sky-500' : 'bg-slate-600 cursor-not-allowed'}`}
+            disabled={!canSubmit || isSubmitting}
+          >
+            {isSubmitting ? '建立中...' : '建立事件'}
+          </button>
+        </div>
+      )}
+    >
+      {isLoading ? (
+        <div className="flex items-center justify-center py-12">
+          <Icon name="loader-circle" className="w-6 h-6 animate-spin text-slate-400" />
+        </div>
+      ) : error ? (
+        <div className="rounded-lg border border-red-500/40 bg-red-500/10 px-4 py-3 text-sm text-red-300">{error}</div>
+      ) : (
+        <form id="new-incident-form" onSubmit={handleSubmit} className="space-y-4">
+          <div>
+            <label className="block text-sm font-medium text-slate-300 mb-1">事件摘要</label>
+            <input
+              type="text"
+              value={form.summary}
+              onChange={e => handleInputChange('summary', e.target.value)}
+              className="w-full rounded-md border border-slate-700 bg-slate-900/60 px-3 py-2 text-sm text-white focus:border-sky-500 focus:outline-none"
+              placeholder="請輸入事件摘要"
+              required
+            />
+          </div>
+          <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+            <div>
+              <label className="block text-sm font-medium text-slate-300 mb-1">影響資源</label>
+              <select
+                value={form.resourceId}
+                onChange={e => handleInputChange('resourceId', e.target.value)}
+                className="w-full rounded-md border border-slate-700 bg-slate-900/60 px-3 py-2 text-sm text-white focus:border-sky-500 focus:outline-none"
+              >
+                <option value="" disabled>選擇資源</option>
+                {resources.map(resource => (
+                  <option key={resource.id} value={resource.id}>{resource.name}</option>
+                ))}
+              </select>
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-slate-300 mb-1">觸發規則</label>
+              <select
+                value={form.ruleId}
+                onChange={e => handleInputChange('ruleId', e.target.value)}
+                className="w-full rounded-md border border-slate-700 bg-slate-900/60 px-3 py-2 text-sm text-white focus:border-sky-500 focus:outline-none"
+              >
+                <option value="" disabled>選擇規則</option>
+                {rules.map(rule => (
+                  <option key={rule.id} value={rule.id}>{rule.name}</option>
+                ))}
+              </select>
+            </div>
+          </div>
+          <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
+            <div>
+              <label className="block text-sm font-medium text-slate-300 mb-1">嚴重程度</label>
+              <select
+                value={form.severity}
+                onChange={e => handleInputChange('severity', e.target.value as Incident['severity'])}
+                className="w-full rounded-md border border-slate-700 bg-slate-900/60 px-3 py-2 text-sm text-white focus:border-sky-500 focus:outline-none"
+              >
+                {incidentOptions?.severities?.map(option => (
+                  <option key={option.value} value={option.value}>{option.label}</option>
+                ))}
+              </select>
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-slate-300 mb-1">服務影響</label>
+              <select
+                value={form.serviceImpact}
+                onChange={e => handleInputChange('serviceImpact', e.target.value as Incident['serviceImpact'])}
+                className="w-full rounded-md border border-slate-700 bg-slate-900/60 px-3 py-2 text-sm text-white focus:border-sky-500 focus:outline-none"
+              >
+                {incidentOptions?.serviceImpacts?.map(option => (
+                  <option key={option.value} value={option.value}>{option.label}</option>
+                ))}
+              </select>
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-slate-300 mb-1">優先順序</label>
+              <select
+                value={form.priority || ''}
+                onChange={e => handleInputChange('priority', e.target.value ? (e.target.value as Incident['priority']) : undefined)}
+                className="w-full rounded-md border border-slate-700 bg-slate-900/60 px-3 py-2 text-sm text-white focus:border-sky-500 focus:outline-none"
+              >
+                <option value="">未指定</option>
+                {incidentOptions?.priorities?.map(option => (
+                  <option key={option.value} value={option.value}>{option.label}</option>
+                ))}
+              </select>
+            </div>
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-slate-300 mb-1">指定負責人 (選填)</label>
+            <input
+              type="text"
+              value={form.assignee || ''}
+              onChange={e => handleInputChange('assignee', e.target.value)}
+              className="w-full rounded-md border border-slate-700 bg-slate-900/60 px-3 py-2 text-sm text-white focus:border-sky-500 focus:outline-none"
+              placeholder="請輸入負責人名稱"
+            />
+          </div>
+        </form>
+      )}
+    </Modal>
+  );
+};
+
+export default NewIncidentModal;

--- a/components/RuleAnalysisDisplay.tsx
+++ b/components/RuleAnalysisDisplay.tsx
@@ -1,0 +1,160 @@
+import React from 'react';
+import Icon from './Icon';
+import { RuleAnalysisReport } from '../types';
+
+interface RuleAnalysisDisplayProps {
+    report: RuleAnalysisReport | null;
+    isLoading: boolean;
+    error: string | null;
+}
+
+const severityStyles: Record<'low' | 'medium' | 'high', string> = {
+    low: 'text-emerald-300 border-emerald-500/40 bg-emerald-500/10',
+    medium: 'text-amber-300 border-amber-500/40 bg-amber-500/10',
+    high: 'text-red-300 border-red-500/40 bg-red-500/10',
+};
+
+const priorityLabels: Record<'low' | 'medium' | 'high', string> = {
+    low: '低',
+    medium: '中',
+    high: '高',
+};
+
+const RuleAnalysisDisplay: React.FC<RuleAnalysisDisplayProps> = ({ report, isLoading, error }) => {
+    if (isLoading) {
+        return (
+            <div className="flex flex-col items-center justify-center h-64">
+                <Icon name="loader-circle" className="w-12 h-12 text-purple-400 animate-spin" />
+                <p className="mt-4 text-slate-300">正在生成 AI 分析報告，請稍候...</p>
+            </div>
+        );
+    }
+
+    if (error) {
+        return (
+            <div className="flex flex-col items-center justify-center h-64 text-red-400">
+                <Icon name="server-crash" className="w-12 h-12 mb-4" />
+                <p className="font-semibold">AI 分析失敗</p>
+                <p className="text-sm mt-2 text-center px-6">{error}</p>
+            </div>
+        );
+    }
+
+    if (!report) {
+        return (
+            <div className="flex flex-col items-center justify-center h-64 text-slate-400">
+                <Icon name="alert-circle" className="w-12 h-12 mb-4" />
+                <p>沒有可顯示的分析結果。</p>
+            </div>
+        );
+    }
+
+    return (
+        <div className="space-y-8 text-slate-200">
+            <section>
+                <h3 className="text-lg font-semibold text-purple-300 mb-2 flex items-center">
+                    <Icon name="file-text" className="w-5 h-5 mr-2" />
+                    分析摘要
+                </h3>
+                <p className="leading-relaxed">{report.summary}</p>
+            </section>
+
+            {report.evaluatedRules.length > 0 && (
+                <section>
+                    <h3 className="text-lg font-semibold text-purple-300 mb-2 flex items-center">
+                        <Icon name="list-checks" className="w-5 h-5 mr-2" />
+                        分析範圍
+                    </h3>
+                    <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+                        {report.evaluatedRules.map(rule => (
+                            <div key={rule.id} className="glass-card border border-slate-700/60 rounded-lg p-3">
+                                <p className="text-sm font-semibold text-white">{rule.name}</p>
+                                <div className="mt-2 flex flex-wrap gap-2 text-xs text-slate-300">
+                                    <span className="px-2 py-0.5 rounded-full bg-slate-800/80 border border-slate-600/80">
+                                        狀態：{rule.status}
+                                    </span>
+                                    {rule.severity && (
+                                        <span className={`px-2 py-0.5 rounded-full border ${severityStyles[rule.severity]} capitalize`}>
+                                            嚴重度：{rule.severity}
+                                        </span>
+                                    )}
+                                    {rule.type && (
+                                        <span className="px-2 py-0.5 rounded-full bg-slate-800/80 border border-slate-600/80">
+                                            類型：{rule.type}
+                                        </span>
+                                    )}
+                                </div>
+                            </div>
+                        ))}
+                    </div>
+                </section>
+            )}
+
+            {report.metrics.length > 0 && (
+                <section>
+                    <h3 className="text-lg font-semibold text-purple-300 mb-2 flex items-center">
+                        <Icon name="activity" className="w-5 h-5 mr-2" />
+                        關鍵指標
+                    </h3>
+                    <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
+                        {report.metrics.map((metric, idx) => (
+                            <div key={`${metric.label}-${idx}`} className="glass-card border border-slate-700/60 rounded-lg p-4">
+                                <p className="text-sm text-slate-400">{metric.label}</p>
+                                <p className="text-2xl font-semibold text-white mt-2">{metric.value}</p>
+                                {metric.description && (
+                                    <p className="text-xs text-slate-400 mt-2 leading-relaxed">{metric.description}</p>
+                                )}
+                            </div>
+                        ))}
+                    </div>
+                </section>
+            )}
+
+            {report.insights.length > 0 && (
+                <section>
+                    <h3 className="text-lg font-semibold text-purple-300 mb-2 flex items-center">
+                        <Icon name="alert-triangle" className="w-5 h-5 mr-2" />
+                        關鍵洞察
+                    </h3>
+                    <div className="space-y-3">
+                        {report.insights.map((insight, idx) => (
+                            <div key={`${insight.title}-${idx}`} className="glass-card border border-slate-700/60 rounded-lg p-4">
+                                <div className="flex items-center justify-between">
+                                    <h4 className="text-sm font-semibold text-white">{insight.title}</h4>
+                                    <span className={`text-xs px-2 py-0.5 rounded-full border ${severityStyles[insight.severity]}`}>
+                                        風險：{priorityLabels[insight.severity]}
+                                    </span>
+                                </div>
+                                <p className="text-sm text-slate-300 mt-2 leading-relaxed">{insight.detail}</p>
+                            </div>
+                        ))}
+                    </div>
+                </section>
+            )}
+
+            {report.recommendations.length > 0 && (
+                <section>
+                    <h3 className="text-lg font-semibold text-purple-300 mb-2 flex items-center">
+                        <Icon name="wrench" className="w-5 h-5 mr-2" />
+                        建議措施
+                    </h3>
+                    <div className="space-y-3">
+                        {report.recommendations.map((recommendation, idx) => (
+                            <div key={`${recommendation.action}-${idx}`} className="glass-card border border-slate-700/60 rounded-lg p-4">
+                                <div className="flex items-center justify-between">
+                                    <h4 className="text-sm font-semibold text-white">{recommendation.action}</h4>
+                                    <span className={`text-xs px-2 py-0.5 rounded-full border ${severityStyles[recommendation.priority]}`}>
+                                        優先度：{priorityLabels[recommendation.priority]}
+                                    </span>
+                                </div>
+                                <p className="text-sm text-slate-300 mt-2 leading-relaxed">{recommendation.description}</p>
+                            </div>
+                        ))}
+                    </div>
+                </section>
+            )}
+        </div>
+    );
+};
+
+export default RuleAnalysisDisplay;

--- a/components/RuleAnalysisModal.tsx
+++ b/components/RuleAnalysisModal.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import Modal from './Modal';
+import RuleAnalysisDisplay from './RuleAnalysisDisplay';
+import { RuleAnalysisReport } from '../types';
+
+interface RuleAnalysisModalProps {
+    isOpen: boolean;
+    onClose: () => void;
+    title: string;
+    report: RuleAnalysisReport | null;
+    isLoading: boolean;
+    error: string | null;
+}
+
+const RuleAnalysisModal: React.FC<RuleAnalysisModalProps> = ({ isOpen, onClose, title, report, isLoading, error }) => {
+    return (
+        <Modal
+            title={title}
+            isOpen={isOpen}
+            onClose={onClose}
+            width="w-2/3"
+            footer={
+                <button
+                    onClick={onClose}
+                    className="px-4 py-2 text-sm font-medium text-slate-300 bg-slate-700 hover:bg-slate-600 rounded-md transition-colors"
+                >
+                    關閉
+                </button>
+            }
+        >
+            <RuleAnalysisDisplay report={report} isLoading={isLoading} error={error} />
+        </Modal>
+    );
+};
+
+export default RuleAnalysisModal;

--- a/contexts/ThemeContext.tsx
+++ b/contexts/ThemeContext.tsx
@@ -1,0 +1,54 @@
+import React, { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
+
+type Theme = 'light' | 'dark';
+
+interface ThemeContextValue {
+  theme: Theme;
+  setTheme: (value: Theme) => void;
+  toggleTheme: () => void;
+}
+
+const STORAGE_KEY = 'sre-platform-theme';
+
+const ThemeContext = createContext<ThemeContextValue | undefined>(undefined);
+
+const getInitialTheme = (): Theme => {
+  if (typeof window === 'undefined') {
+    return 'dark';
+  }
+  const stored = window.localStorage.getItem(STORAGE_KEY);
+  return stored === 'light' ? 'light' : 'dark';
+};
+
+export const ThemeProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [theme, setThemeState] = useState<Theme>(getInitialTheme);
+
+  useEffect(() => {
+    if (typeof document !== 'undefined') {
+      document.documentElement.setAttribute('data-theme', theme);
+    }
+    if (typeof window !== 'undefined') {
+      window.localStorage.setItem(STORAGE_KEY, theme);
+    }
+  }, [theme]);
+
+  const setTheme = useCallback((value: Theme) => {
+    setThemeState(value);
+  }, []);
+
+  const toggleTheme = useCallback(() => {
+    setThemeState(prev => (prev === 'dark' ? 'light' : 'dark'));
+  }, []);
+
+  const value = useMemo(() => ({ theme, setTheme, toggleTheme }), [theme, setTheme, toggleTheme]);
+
+  return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>;
+};
+
+export const useTheme = (): ThemeContextValue => {
+  const context = useContext(ThemeContext);
+  if (!context) {
+    throw new Error('useTheme must be used within a ThemeProvider');
+  }
+  return context;
+};

--- a/index.html
+++ b/index.html
@@ -8,34 +8,59 @@
     <script src="https://unpkg.com/lucide@latest"></script>
     <script src="https://cdn.jsdelivr.net/npm/echarts@5.5.0/dist/echarts.min.js"></script>
     <style>
+      :root {
+        --background-color: #020617;
+        --text-color: #f8fafc;
+        --glass-card-bg: rgba(30, 41, 59, 0.5);
+        --glass-card-border: rgba(51, 65, 85, 0.5);
+        --glass-header-bg: rgba(15, 23, 42, 0.6);
+        --glass-header-border: rgba(51, 65, 85, 0.5);
+        --scrollbar-track: rgba(30, 41, 59, 0.5);
+        --scrollbar-thumb: #475569;
+        --scrollbar-thumb-hover: #64748b;
+      }
+      :root[data-theme='light'] {
+        --background-color: #f8fafc;
+        --text-color: #0f172a;
+        --glass-card-bg: rgba(255, 255, 255, 0.8);
+        --glass-card-border: rgba(148, 163, 184, 0.45);
+        --glass-header-bg: rgba(241, 245, 249, 0.85);
+        --glass-header-border: rgba(148, 163, 184, 0.6);
+        --scrollbar-track: rgba(241, 245, 249, 0.8);
+        --scrollbar-thumb: #94a3b8;
+        --scrollbar-thumb-hover: #64748b;
+      }
       body {
-        background-color: #020617; /* slate-950 */
-        color: #f8fafc; /* slate-50 */
+        background-color: var(--background-color);
+        color: var(--text-color);
         overflow: hidden;
+        transition: background-color 0.3s ease, color 0.3s ease;
       }
       .glass-card {
-        background-color: rgba(30, 41, 59, 0.5); /* slate-800/50 */
+        background-color: var(--glass-card-bg);
         backdrop-filter: blur(12px);
-        border: 1px solid rgba(51, 65, 85, 0.5); /* slate-700/50 */
+        border: 1px solid var(--glass-card-border);
+        transition: background-color 0.3s ease, border-color 0.3s ease;
       }
       .glass-header {
-        background-color: rgba(15, 23, 42, 0.6); /* slate-900/60 */
+        background-color: var(--glass-header-bg);
         backdrop-filter: blur(12px);
-        border-bottom: 1px solid rgba(51, 65, 85, 0.5); /* slate-700/50 */
+        border-bottom: 1px solid var(--glass-header-border);
+        transition: background-color 0.3s ease, border-color 0.3s ease;
       }
       ::-webkit-scrollbar {
         width: 6px;
         height: 6px;
       }
       ::-webkit-scrollbar-track {
-        background: rgba(30, 41, 59, 0.5);
+        background: var(--scrollbar-track);
       }
       ::-webkit-scrollbar-thumb {
-        background: #475569; /* slate-600 */
+        background: var(--scrollbar-thumb);
         border-radius: 3px;
       }
       ::-webkit-scrollbar-thumb:hover {
-        background: #64748b; /* slate-500 */
+        background: var(--scrollbar-thumb-hover);
       }
       /* Syntax Highlighting for Code Editor */
       .token-keyword { color: #c678dd; } /* purple */

--- a/pages/incidents/AlertRulePage.tsx
+++ b/pages/incidents/AlertRulePage.tsx
@@ -1,6 +1,5 @@
-import React, { useState, useMemo, useEffect, useCallback } from 'react';
-// FIX: Import TableColumn from types.ts
-import { AlertRule, TableColumn } from '../../types';
+import React, { useState, useEffect, useCallback } from 'react';
+import { AlertRule, TableColumn, RuleAnalysisReport } from '../../types';
 import Icon from '../../components/Icon';
 import AlertRuleEditModal from '../../components/AlertRuleEditModal';
 import UnifiedSearchModal, { AlertRuleFilters } from '../../components/UnifiedSearchModal';
@@ -16,7 +15,7 @@ import ImportFromCsvModal from '../../components/ImportFromCsvModal';
 import ColumnSettingsModal from '../../components/ColumnSettingsModal';
 import { showToast } from '../../services/toast';
 import { usePageMetadata } from '../../contexts/PageMetadataContext';
-import PlaceholderModal from '../../components/PlaceholderModal';
+import RuleAnalysisModal from '../../components/RuleAnalysisModal';
 
 const PAGE_IDENTIFIER = 'alert_rules';
 
@@ -36,8 +35,10 @@ const AlertRulePage: React.FC = () => {
     const [isImportModalOpen, setIsImportModalOpen] = useState(false);
     const [isColumnSettingsModalOpen, setIsColumnSettingsModalOpen] = useState(false);
     const [visibleColumns, setVisibleColumns] = useState<string[]>([]);
-    const [isPlaceholderModalOpen, setIsPlaceholderModalOpen] = useState(false);
-    const [modalFeatureName, setModalFeatureName] = useState('');
+    const [isAnalysisModalOpen, setIsAnalysisModalOpen] = useState(false);
+    const [analysisReport, setAnalysisReport] = useState<RuleAnalysisReport | null>(null);
+    const [analysisError, setAnalysisError] = useState<string | null>(null);
+    const [isAnalysisLoading, setIsAnalysisLoading] = useState(false);
 
     const { metadata: pageMetadata } = usePageMetadata();
     const pageKey = pageMetadata?.[PAGE_IDENTIFIER]?.columnConfigKey;
@@ -181,9 +182,24 @@ const AlertRulePage: React.FC = () => {
         }
     };
 
-    const handleAIAnalysis = () => {
-        setModalFeatureName('分析告警規則');
-        setIsPlaceholderModalOpen(true);
+    const handleAIAnalysis = async () => {
+        if (selectedIds.length === 0) {
+            showToast('請先選擇至少一條告警規則。', 'warning');
+            return;
+        }
+        setIsAnalysisModalOpen(true);
+        setAnalysisReport(null);
+        setAnalysisError(null);
+        setIsAnalysisLoading(true);
+        try {
+            const { data } = await api.post<RuleAnalysisReport>('/ai/alert-rules/analyze', { rule_ids: selectedIds });
+            setAnalysisReport(data);
+        } catch (err: any) {
+            const message = err?.response?.data?.message || '無法取得 AI 分析結果。';
+            setAnalysisError(message);
+        } finally {
+            setIsAnalysisLoading(false);
+        }
     };
 
     const handleExport = () => {
@@ -355,10 +371,13 @@ const AlertRulePage: React.FC = () => {
                 templateHeaders={['name', 'description', 'enabled', 'severity', 'conditionsSummary']}
                 templateFilename="alert-rules-template.csv"
             />
-             <PlaceholderModal
-                isOpen={isPlaceholderModalOpen}
-                onClose={() => setIsPlaceholderModalOpen(false)}
-                featureName={modalFeatureName}
+            <RuleAnalysisModal
+                isOpen={isAnalysisModalOpen}
+                onClose={() => setIsAnalysisModalOpen(false)}
+                title="AI 告警規則分析"
+                report={analysisReport}
+                isLoading={isAnalysisLoading}
+                error={analysisError}
             />
         </div>
     );

--- a/types.ts
+++ b/types.ts
@@ -71,6 +71,43 @@ export interface MultiIncidentAnalysis {
   group_actions: GroupActionRecommendation[];
 }
 
+export type RuleAnalysisSeverity = 'low' | 'medium' | 'high';
+
+export interface RuleAnalysisEvaluatedRule {
+  id: string;
+  name: string;
+  status: string;
+  severity?: RuleAnalysisSeverity;
+  type?: string;
+}
+
+export interface RuleAnalysisMetric {
+  label: string;
+  value: string;
+  description?: string;
+}
+
+export interface RuleAnalysisInsight {
+  title: string;
+  detail: string;
+  severity: RuleAnalysisSeverity;
+}
+
+export interface RuleAnalysisRecommendation {
+  action: string;
+  description: string;
+  priority: RuleAnalysisSeverity;
+}
+
+export interface RuleAnalysisReport {
+  reportType: 'alert' | 'silence';
+  summary: string;
+  evaluatedRules: RuleAnalysisEvaluatedRule[];
+  metrics: RuleAnalysisMetric[];
+  insights: RuleAnalysisInsight[];
+  recommendations: RuleAnalysisRecommendation[];
+}
+
 export interface Incident {
   id: string;
   summary: string;
@@ -86,6 +123,16 @@ export interface Incident {
   triggeredAt: string;
   history: IncidentEvent[];
   aiAnalysis?: IncidentAnalysis;
+}
+
+export interface IncidentCreateRequest {
+  summary: string;
+  resourceId: string;
+  ruleId: string;
+  severity: Incident['severity'];
+  serviceImpact: Incident['serviceImpact'];
+  priority?: Incident['priority'];
+  assignee?: string;
 }
 
 export interface LayoutWidget {


### PR DESCRIPTION
## Summary
- remove the unused zoom/share placeholder controls from the dashboard viewer header
- add reusable rule analysis modal/display components and wire the alert/silence rule pages to new AI analysis endpoints
- extend the mock server data and handlers with alert/silence rule AI responses consumed by the new front-end flows

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68da92506e2c832d8934a0d652301c5a