### PR TITLE
refactor: 以 mock 選項取代事件與規則的硬編碼標籤

### DIFF
--- a/mock-server/db.ts
+++ b/mock-server/db.ts
@@ -1891,12 +1891,18 @@ const MOCK_INCIDENT_OPTIONS: IncidentOptions = {
     ],
 };
 
+const ALERT_RULE_SEVERITY_DESCRIPTORS: Record<AlertRule['severity'], { label: string; className: string }> = {
+    critical: { label: '嚴重', className: 'bg-red-950/40 border border-red-500/40 text-red-300 backdrop-blur-sm shadow-sm' },
+    warning: { label: '警告', className: 'bg-amber-950/40 border border-amber-500/40 text-amber-300 backdrop-blur-sm shadow-sm' },
+    info: { label: '資訊', className: 'bg-sky-950/40 border border-sky-500/40 text-sky-300 backdrop-blur-sm shadow-sm' },
+};
+
 const MOCK_ALERT_RULE_OPTIONS: AlertRuleOptions = {
-    severities: [
-        { value: 'critical', label: 'Critical', className: 'bg-red-950/40 border border-red-500/40 text-red-300 backdrop-blur-sm shadow-sm' },
-        { value: 'warning', label: 'Warning', className: 'bg-amber-950/40 border border-amber-500/40 text-amber-300 backdrop-blur-sm shadow-sm' },
-        { value: 'info', label: 'Info', className: 'bg-sky-950/40 border border-sky-500/40 text-sky-300 backdrop-blur-sm shadow-sm' },
-    ],
+    severities: (['critical', 'warning', 'info'] as AlertRule['severity'][]).map(value => ({
+        value,
+        label: ALERT_RULE_SEVERITY_DESCRIPTORS[value].label,
+        className: ALERT_RULE_SEVERITY_DESCRIPTORS[value].className,
+    })),
     statuses: [
         { value: true, label: 'Enabled' },
         { value: false, label: 'Disabled' }
@@ -1947,11 +1953,17 @@ const MOCK_AUTOMATION_SCRIPT_OPTIONS: AutomationScriptOptions = {
 
 const MOCK_AUTOMATION_EXECUTION_OPTIONS: AutomationExecutionOptions = {
     statuses: [
-        { value: 'success', label: 'Success', className: 'bg-green-500/20 text-green-400' },
-        { value: 'failed', label: 'Failed', className: 'bg-red-500/20 text-red-400' },
-        { value: 'running', label: 'Running', className: 'bg-sky-500/20 text-sky-400' },
-        { value: 'pending', label: 'Pending', className: 'bg-yellow-500/20 text-yellow-400' },
-    ]
+        { value: 'success', label: '成功', className: 'bg-green-500/20 text-green-400' },
+        { value: 'failed', label: '失敗', className: 'bg-red-500/20 text-red-400' },
+        { value: 'running', label: '執行中', className: 'bg-sky-500/20 text-sky-400' },
+        { value: 'pending', label: '等待中', className: 'bg-yellow-500/20 text-yellow-400' },
+    ],
+    triggerSources: [
+        { value: 'event', label: '事件觸發' },
+        { value: 'manual', label: '手動執行' },
+        { value: 'schedule', label: '排程觸發' },
+        { value: 'webhook', label: 'Webhook' },
+    ],
 };
 
 const MOCK_NOTIFICATION_CHANNEL_OPTIONS: NotificationChannelOptions = {

--- a/pages/automation/AutomationHistoryPage.tsx
+++ b/pages/automation/AutomationHistoryPage.tsx
@@ -151,14 +151,9 @@ const AutomationHistoryPage: React.FC = () => {
         return executionOptions.statuses.find(s => s.value === status)?.label || status;
     };
 
-    const getTriggerSourceLabel = (source: string): string => {
-        const sourceMap: Record<string, string> = {
-            'event': '事件觸發',
-            'manual': '手動執行',
-            'schedule': '排程觸發',
-            'webhook': 'Webhook'
-        };
-        return sourceMap[source] || source;
+    const getTriggerSourceLabel = (source: AutomationExecution['triggerSource']): string => {
+        if (!executionOptions?.triggerSources) return source;
+        return executionOptions.triggerSources.find(item => item.value === source)?.label || source;
     };
 
     const renderCellContent = (ex: AutomationExecution, columnKey: string) => {

--- a/pages/incidents/AlertRulePage.tsx
+++ b/pages/incidents/AlertRulePage.tsx
@@ -15,6 +15,7 @@ import ColumnSettingsModal from '../../components/ColumnSettingsModal';
 import { showToast } from '../../services/toast';
 import { usePageMetadata } from '../../contexts/PageMetadataContext';
 import RuleAnalysisModal from '../../components/RuleAnalysisModal';
+import { useOptions } from '../../contexts/OptionsContext';
 
 const PAGE_IDENTIFIER = 'alert_rules';
 
@@ -41,6 +42,9 @@ const AlertRulePage: React.FC = () => {
 
     const { metadata: pageMetadata } = usePageMetadata();
     const pageKey = pageMetadata?.[PAGE_IDENTIFIER]?.columnConfigKey;
+
+    const { options } = useOptions();
+    const alertRuleOptions = options?.alertRules;
 
     const fetchRules = useCallback(async () => {
         if (!pageKey) return;
@@ -226,14 +230,6 @@ const AlertRulePage: React.FC = () => {
         });
     };
 
-    const getSeverityPill = (severity: AlertRule['severity']) => {
-        switch (severity) {
-            case 'critical': return 'border-red-500 text-red-500';
-            case 'warning': return 'border-orange-500 text-orange-500';
-            case 'info': return 'border-sky-500 text-sky-500';
-        }
-    };
-
     const renderCellContent = (rule: AlertRule, columnKey: string) => {
         switch (columnKey) {
             case 'enabled':
@@ -246,9 +242,12 @@ const AlertRulePage: React.FC = () => {
             case 'name': return <span className="font-medium text-white">{rule.name}</span>;
             case 'target': return rule.target;
             case 'conditionsSummary': return rule.conditionsSummary;
-            case 'severity':
-                const severityMap: Record<string, string> = { 'critical': '嚴重', 'warning': '警告', 'info': '資訊' };
-                return <span className={`px-2 py-1 text-xs font-semibold rounded-full border ${getSeverityPill(rule.severity)}`}>{severityMap[rule.severity] || rule.severity}</span>;
+            case 'severity': {
+                const descriptor = alertRuleOptions?.severities.find(option => option.value === rule.severity);
+                const pillClass = descriptor?.className || 'bg-slate-800/60 border border-slate-600 text-slate-200';
+                const label = descriptor?.label || rule.severity;
+                return <span className={`px-2 py-1 text-xs font-semibold rounded-full ${pillClass}`}>{label}</span>;
+            }
             case 'automationEnabled': return rule.automationEnabled ? <Icon name="check-circle" className="w-5 h-5 text-green-400" /> : <Icon name="x-circle" className="w-5 h-5 text-slate-500" />;
             case 'creator': return rule.creator;
             case 'lastUpdated': return rule.lastUpdated;

--- a/pages/incidents/IncidentListPage.tsx
+++ b/pages/incidents/IncidentListPage.tsx
@@ -252,8 +252,7 @@ const IncidentListPage: React.FC = () => {
             case 'status':
                 return <span className={`px-2 py-1 text-xs font-semibold rounded-full ${getStyle(incidentOptions?.statuses, inc.status)}`}>{getLabel(incidentOptions?.statuses, inc.status)}</span>;
             case 'severity':
-                const severityMap: Record<string, string> = { Critical: '嚴重', Warning: '警告', Info: '資訊' };
-                return <span className={`px-2 py-1 text-xs font-semibold rounded-full border ${getStyle(incidentOptions?.severities, inc.severity)}`}>{severityMap[inc.severity] || getLabel(incidentOptions?.severities, inc.severity)}</span>;
+                return <span className={`px-2 py-1 text-xs font-semibold rounded-full border ${getStyle(incidentOptions?.severities, inc.severity)}`}>{getLabel(incidentOptions?.severities, inc.severity)}</span>;
             case 'impact':
                 return <span className={`px-2 py-1 text-xs font-semibold rounded-full border ${getStyle(incidentOptions?.impacts, inc.impact)}`}>{getLabel(incidentOptions?.impacts, inc.impact)}</span>;
             case 'resource':

--- a/types.ts
+++ b/types.ts
@@ -209,7 +209,7 @@ export interface AutomationExecution {
   scriptId: string;
   scriptName: string;
   status: 'success' | 'failed' | 'running' | 'pending';
-  triggerSource: 'manual' | 'event' | 'schedule';
+  triggerSource: 'manual' | 'event' | 'schedule' | 'webhook';
   triggeredBy: string;
   startTime: string;
   endTime?: string;
@@ -785,6 +785,7 @@ export interface AlertRuleOptions {
 
 export interface AutomationExecutionOptions {
   statuses: StyleDescriptor<AutomationExecution['status']>[];
+  triggerSources: { value: AutomationExecution['triggerSource']; label: string }[];
 }
 
 export interface AutomationPlaybookOptions {


### PR DESCRIPTION
## Summary
- 調整 mock server 的告警嚴重度與自動化執行選項，提供中文標籤並新增觸發來源設定
- 移除事件與告警列表頁面中的硬編碼字串，改用 OptionsContext 取得的 mock API 資料
- 更新自動化歷史頁面以 mock 選項轉換觸發來源顯示

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dbadcd77cc832d95b0489ee4b5fcf7