### PR TITLE
改用 mock API 驅動資料來源與自動探勘測試

### DIFF
--- a/types.ts
+++ b/types.ts
@@ -871,6 +871,13 @@ export type DatasourceType = 'VictoriaMetrics' | 'Grafana' | 'Elasticsearch' | '
 export type AuthMethod = 'Token' | 'Basic Auth' | 'Keycloak Integration' | 'Keycloak 整合' | 'None' | '無';
 export type ConnectionStatus = 'ok' | 'error' | 'pending';
 
+export interface DatasourceTestResponse {
+  success: boolean;
+  status: ConnectionStatus;
+  latencyMs?: number;
+  message: string;
+}
+
 export interface KeyValueTag {
   id: string;
   key: string;
@@ -917,6 +924,13 @@ export interface DiscoveryJob {
   edgeGateway?: DiscoveryJobEdgeGateway | null;
   tags: KeyValueTag[];
   deleted_at?: string;
+}
+
+export interface DiscoveryTestResponse {
+  success: boolean;
+  discoveredCount: number;
+  message: string;
+  warnings?: string[];
 }
 
 export interface DatasourceFilters {


### PR DESCRIPTION
## Summary
- 調整 Datasource 編輯對話框改呼叫 mock API 測試連線並顯示延遲資訊
- 更新自動探勘編輯對話框使用 mock API 進行掃描測試並強化錯誤提示
- 擴充 mock-server handlers 與型別定義以支援新的測試結果格式

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dbafba6d08832d80412eedc4ba4693