### PR TITLE
Normalize mock db data to snake_case

### DIFF
--- a/mock-server/db.ts
+++ b/mock-server/db.ts
@@ -343,47 +343,47 @@ const PAGE_CONTENT = {
         incidents: {
             title: '事件',
             description: '監控和處理系統異常事件',
-            kpiPageName: '事件'
+            kpi_page_name: '事件'
         },
         resources: {
             title: '資源',
             description: '探索、組織與管理您的所有基礎設施資源',
-            kpiPageName: '資源'
+            kpi_page_name: '資源'
         },
         dashboards: {
             title: '儀表板',
             description: '統一的系統監控與業務洞察儀表板入口',
-            kpiPageName: '儀表板'
+            kpi_page_name: '儀表板'
         },
         analysis: {
             title: '智慧排查',
             description: '深入了解系統趨勢、效能瓶頸和運營數據',
-            kpiPageName: '智慧排查'
+            kpi_page_name: '智慧排查'
         },
         automation: {
             title: '自動化',
             description: '提供自動化腳本管理、排程配置和執行追蹤功能',
-            kpiPageName: '自動化'
+            kpi_page_name: '自動化'
         },
         iam: {
             title: '身份與存取管理',
             description: '統一管理身份認證、存取權限和組織架構配置',
-            kpiPageName: '身份與存取管理'
+            kpi_page_name: '身份與存取管理'
         },
         notification: {
             title: '通知',
             description: '提供統一的通知策略配置、管道管理和歷史記錄查詢功能',
-            kpiPageName: '通知'
+            kpi_page_name: '通知'
         },
-        platformSettings: {
+        platform_settings: {
             title: '平台',
             description: '提供系統全域配置管理，包含標籤、郵件、身份驗證等功能',
-            kpiPageName: '平台'
+            kpi_page_name: '平台'
         },
         profile: {
             title: '個人設定',
             description: '提供用戶個人資訊管理、偏好設定和安全配置功能',
-            kpiPageName: '個人設定'
+            kpi_page_name: '個人設定'
         },
     },
     SRE_WAR_ROOM: {
@@ -810,19 +810,19 @@ const MOCK_EXPORTER_TYPES = [
 ];
 
 const MOCK_SYSTEM_CONFIG = {
-    defaultDashboard: 'sre-war-room',
-    apiBaseUrl: DEFAULT_API_BASE_URL,
+    default_dashboard: 'sre-war-room',
+    api_base_url: DEFAULT_API_BASE_URL,
     theme: 'dark',
-    autoRefreshInterval: 30000,
-    maxLoginAttempts: 5,
-    sessionTimeout: 3600,
+    auto_refresh_interval: 30000,
+    max_login_attempts: 5,
+    session_timeout: 3600,
 };
 
 const MOCK_COMMANDS = [
-    { id: 'cmd_new_incident', name: '> New Incident', description: 'Create a new incident report', icon: 'plus-circle', actionKey: 'new_incident' },
-    { id: 'cmd_silence_resource', name: '> Silence Resource', description: 'Temporarily silence alerts for a specific resource', icon: 'bell-off', actionKey: 'silence_resource' },
-    { id: 'cmd_run_playbook', name: '> Run Playbook', description: 'Execute an automation playbook', icon: 'play-circle', actionKey: 'run_playbook' },
-    { id: 'cmd_change_theme', name: '> Change Theme', description: 'Switch between light and dark mode', icon: 'sun-moon', actionKey: 'change_theme' },
+    { id: 'cmd_new_incident', name: '> New Incident', description: 'Create a new incident report', icon: 'plus-circle', action_key: 'new_incident' },
+    { id: 'cmd_silence_resource', name: '> Silence Resource', description: 'Temporarily silence alerts for a specific resource', icon: 'bell-off', action_key: 'silence_resource' },
+    { id: 'cmd_run_playbook', name: '> Run Playbook', description: 'Execute an automation playbook', icon: 'play-circle', action_key: 'run_playbook' },
+    { id: 'cmd_change_theme', name: '> Change Theme', description: 'Switch between light and dark mode', icon: 'sun-moon', action_key: 'change_theme' },
 ];
 
 const MOCK_COMMAND_PALETTE_CONTENT = {
@@ -872,7 +872,7 @@ const MOCK_ALL_COLUMNS: Record<string, TableColumn[]> = {
         { key: 'type', label: '類型' },
         { key: 'category', label: '分類' },
         { key: 'owner', label: '擁有者' },
-        { key: 'updatedAt', label: '最後更新' },
+        { key: 'updated_at', label: '最後更新' },
     ],
     incidents: [
         { key: 'summary', label: '摘要' },
@@ -891,21 +891,21 @@ const MOCK_ALL_COLUMNS: Record<string, TableColumn[]> = {
         { key: 'provider', label: '供應商' },
         { key: 'region', label: '地區' },
         { key: 'owner', label: '擁有者' },
-        { key: 'lastCheckInAt', label: '最後簽入' },
+        { key: 'last_check_in_at', label: '最後簽入' },
     ],
     resource_groups: [
         { key: 'name', label: '群組名稱' },
-        { key: 'ownerTeam', label: '擁有團隊' },
-        { key: 'memberIds', label: '成員數量' },
-        { key: 'statusSummary', label: '狀態' },
+        { key: 'owner_team', label: '擁有團隊' },
+        { key: 'member_ids', label: '成員數量' },
+        { key: 'status_summary', label: '狀態' },
     ],
     alert_rules: [
         { key: 'enabled', label: '啟用' },
         { key: 'name', label: '規則名稱' },
         { key: 'target', label: '監控對象' },
-        { key: 'conditionsSummary', label: '觸發條件' },
+        { key: 'conditions_summary', label: '觸發條件' },
         { key: 'severity', label: '嚴重程度' },
-        { key: 'automationEnabled', label: '自動化' },
+        { key: 'automation_enabled', label: '自動化' },
         { key: 'creator', label: '創建者' },
         { key: 'updated_at', label: '最後更新' },
     ],
@@ -921,42 +921,42 @@ const MOCK_ALL_COLUMNS: Record<string, TableColumn[]> = {
     automation_playbooks: [
         { key: 'name', label: '腳本名稱' },
         { key: 'trigger', label: '觸發器' },
-        { key: 'lastRunStatus', label: '上次運行狀態' },
-        { key: 'lastRunAt', label: '上次運行時間' },
-        { key: 'runCount', label: '運行次數' },
+        { key: 'last_run_status', label: '上次運行狀態' },
+        { key: 'last_run_at', label: '上次運行時間' },
+        { key: 'run_count', label: '運行次數' },
     ],
     automation_triggers: [
         { key: 'enabled', label: '啟用' },
         { key: 'name', label: '名稱' },
         { key: 'type', label: '類型' },
-        { key: 'targetPlaybookId', label: '目標腳本' },
-        { key: 'lastTriggeredAt', label: '上次觸發' },
+        { key: 'target_playbook_id', label: '目標腳本' },
+        { key: 'last_triggered_at', label: '上次觸發' },
     ],
     automation_history: [
-        { key: 'scriptName', label: '腳本名稱' },
+        { key: 'script_name', label: '腳本名稱' },
         { key: 'status', label: '狀態' },
-        { key: 'triggerSource', label: '觸發來源' },
-        { key: 'triggeredBy', label: '觸發者' },
-        { key: 'startTime', label: '開始時間' },
-        { key: 'durationMs', label: '耗時' },
+        { key: 'trigger_source', label: '觸發來源' },
+        { key: 'triggered_by', label: '觸發者' },
+        { key: 'start_time', label: '開始時間' },
+        { key: 'duration_ms', label: '耗時' },
     ],
     personnel: [
         { key: 'name', label: '名稱' },
         { key: 'role', label: '角色' },
         { key: 'team', label: '團隊' },
         { key: 'status', label: '狀態' },
-        { key: 'lastLoginAt', label: '上次登入' },
+        { key: 'last_login_at', label: '上次登入' },
     ],
     teams: [
         { key: 'name', label: '團隊名稱' },
-        { key: 'ownerId', label: '擁有者' },
-        { key: 'memberIds', label: '成員數' },
+        { key: 'owner_id', label: '擁有者' },
+        { key: 'member_ids', label: '成員數' },
         { key: 'created_at', label: '創建時間' },
     ],
     roles: [
         { key: 'enabled', label: '啟用' },
         { key: 'name', label: '角色名稱' },
-        { key: 'userCount', label: '使用者數量' },
+        { key: 'user_count', label: '使用者數量' },
         { key: 'created_at', label: '創建時間' },
     ],
     audit_logs: [
@@ -970,10 +970,10 @@ const MOCK_ALL_COLUMNS: Record<string, TableColumn[]> = {
     notification_strategies: [
         { key: 'enabled', label: '啟用' },
         { key: 'name', label: '策略名稱' },
-        { key: 'triggerCondition', label: '觸發條件' },
-        { key: 'channelCount', label: '管道數' },
-        { key: 'severityLevels', label: '嚴重程度' },
-        { key: 'impactLevels', label: '影響範圍' },
+        { key: 'trigger_condition', label: '觸發條件' },
+        { key: 'channel_count', label: '管道數' },
+        { key: 'severity_levels', label: '嚴重程度' },
+        { key: 'impact_levels', label: '影響範圍' },
         { key: 'creator', label: '創建者' },
         { key: 'updated_at', label: '最後更新' },
     ],
@@ -981,8 +981,8 @@ const MOCK_ALL_COLUMNS: Record<string, TableColumn[]> = {
         { key: 'enabled', label: '啟用' },
         { key: 'name', label: '管道名稱' },
         { key: 'type', label: '類型' },
-        { key: 'lastTestResult', label: '最新發送結果' },
-        { key: 'lastTestedAt', label: '最新發送時間' },
+        { key: 'last_test_result', label: '最新發送結果' },
+        { key: 'last_tested_at', label: '最新發送時間' },
     ],
     notification_history: [
         { key: 'timestamp', label: '時間' },
@@ -995,10 +995,10 @@ const MOCK_ALL_COLUMNS: Record<string, TableColumn[]> = {
     tag_management: [
         { key: 'key', label: '標籤鍵' },
         { key: 'description', label: '說明' },
-        { key: 'enumValues', label: '標籤值' },
+        { key: 'enum_values', label: '標籤值' },
         { key: 'required', label: '必填' },
         { key: 'scopes', label: '適用範圍' },
-        { key: 'writableRoles', label: '可寫入角色' },
+        { key: 'writable_roles', label: '可寫入角色' },
     ],
     datasources: [
         { key: 'name', label: '資料來源名稱' },
@@ -1013,32 +1013,32 @@ const MOCK_ALL_COLUMNS: Record<string, TableColumn[]> = {
         { key: 'kind', label: '類型' },
         { key: 'status', label: '狀態' },
         { key: 'schedule', label: '排程' },
-        { key: 'lastRunAt', label: '最後執行' },
+        { key: 'last_run_at', label: '最後執行' },
         { key: 'created_at', label: '建立時間' },
     ],
 };
 
-const MOCK_PAGE_METADATA: Record<string, { columnConfigKey: string }> = {
-    'dashboards': { columnConfigKey: 'dashboards' },
-    'incidents': { columnConfigKey: 'incidents' },
-    'resources': { columnConfigKey: 'resources' },
-    'datasources': { columnConfigKey: 'datasources' },
-    'autodiscovery': { columnConfigKey: 'autodiscovery' },
-    'personnel': { columnConfigKey: 'personnel' },
-    'alert_rules': { columnConfigKey: 'alert_rules' },
-    'silence_rules': { columnConfigKey: 'silence_rules' },
-    'resource_groups': { columnConfigKey: 'resource_groups' },
-    'automation_playbooks': { columnConfigKey: 'automation_playbooks' },
-    'automation_history': { columnConfigKey: 'automation_history' },
-    'automation_triggers': { columnConfigKey: 'automation_triggers' },
-    'teams': { columnConfigKey: 'teams' },
-    'roles': { columnConfigKey: 'roles' },
-    'audit_logs': { columnConfigKey: 'audit_logs' },
-    'tag_management': { columnConfigKey: 'tag_management' },
-    'notification_strategies': { columnConfigKey: 'notification_strategies' },
-    'notification_channels': { columnConfigKey: 'notification_channels' },
-    'notification_history': { columnConfigKey: 'notification_history' },
-    'ResourceOverview': { columnConfigKey: '' },
+const MOCK_PAGE_METADATA: Record<string, { column_config_key: string }> = {
+    'dashboards': { column_config_key: 'dashboards' },
+    'incidents': { column_config_key: 'incidents' },
+    'resources': { column_config_key: 'resources' },
+    'datasources': { column_config_key: 'datasources' },
+    'autodiscovery': { column_config_key: 'autodiscovery' },
+    'personnel': { column_config_key: 'personnel' },
+    'alert_rules': { column_config_key: 'alert_rules' },
+    'silence_rules': { column_config_key: 'silence_rules' },
+    'resource_groups': { column_config_key: 'resource_groups' },
+    'automation_playbooks': { column_config_key: 'automation_playbooks' },
+    'automation_history': { column_config_key: 'automation_history' },
+    'automation_triggers': { column_config_key: 'automation_triggers' },
+    'teams': { column_config_key: 'teams' },
+    'roles': { column_config_key: 'roles' },
+    'audit_logs': { column_config_key: 'audit_logs' },
+    'tag_management': { column_config_key: 'tag_management' },
+    'notification_strategies': { column_config_key: 'notification_strategies' },
+    'notification_channels': { column_config_key: 'notification_channels' },
+    'notification_history': { column_config_key: 'notification_history' },
+    'ResourceOverview': { column_config_key: '' },
 };
 
 const MOCK_ICON_MAP: Record<string, string> = {
@@ -1067,37 +1067,37 @@ const MOCK_CHART_COLORS: ChartTheme = {
     },
     grid: {
         axis: '#94a3b8',
-        splitLine: '#334155',
+        split_line: '#334155',
     },
     background: {
         card: '#0f172a',
         accent: '#1e293b',
     },
-    healthGauge: {
+    health_gauge: {
         critical: '#dc2626',
         warning: '#f97316',
         healthy: '#10b981',
     },
-    eventCorrelation: ['#dc2626', '#f97316', '#10b981'],
+    event_correlation: ['#dc2626', '#f97316', '#10b981'],
     severity: {
         critical: '#dc2626',
         warning: '#f97316',
         info: '#10b981',
     },
-    logLevels: {
+    log_levels: {
         error: '#f87171',
         warning: '#facc15',
         info: '#38bdf8',
         debug: '#94a3b8',
     },
-    capacityPlanning: {
+    capacity_planning: {
         cpu: '#38bdf8',
         memory: '#a78bfa',
         storage: '#34d399',
         forecast: '#facc15',
         baseline: '#64748b',
     },
-    resourceDistribution: {
+    resource_distribution: {
         primary: '#38bdf8',
         border: '#1e293b',
         axis: '#94a3b8',
@@ -1108,8 +1108,8 @@ const MOCK_CHART_COLORS: ChartTheme = {
         low: '#10b981',
     },
     topology: {
-        nodeBorder: '#f8fafc',
-        nodeLabel: '#cbd5e1',
+        node_border: '#f8fafc',
+        node_label: '#cbd5e1',
         edge: '#475569',
     },
     heatmap: {
@@ -1151,8 +1151,8 @@ const MOCK_DASHBOARDS: Dashboard[] = [
         updated_at: '2025-09-27T10:00:00Z',
         path: '/dashboard/resource-overview'
     },
-    { id: 'api-service-status', name: 'API 服務狀態', type: 'grafana', category: '業務與 SLA', description: 'API 響應時間、錯誤率、吞吐量等服務指標。', owner: 'SRE 平台團隊', created_at: '2025-09-18T16:45:00Z', updated_at: '2025-09-18T16:45:00Z', path: '/dashboard/api-service-status', grafanaUrl: `${DEFAULT_GRAFANA_BASE_URL}/d/aead3d54-423b-4a91-b91c-dbdf40d7fff5`, grafana_dashboard_uid: 'aead3d54-423b-4a91-b91c-dbdf40d7fff5', grafana_folder_uid: 'biz-folder' },
-    { id: 'user-experience-monitoring', name: '用戶體驗監控', type: 'grafana', category: '營運與容量', description: '頁面載入時間、用戶行為分析、錯誤追蹤。', owner: '前端團隊', created_at: '2025-09-18T17:00:00Z', updated_at: '2025-09-18T17:00:00Z', path: '/dashboard/user-experience-monitoring', grafanaUrl: `${DEFAULT_GRAFANA_BASE_URL}/d/another-dashboard-id-for-ux`, grafana_dashboard_uid: 'another-dashboard-id-for-ux', grafana_folder_uid: 'ux-folder' },
+    { id: 'api-service-status', name: 'API 服務狀態', type: 'grafana', category: '業務與 SLA', description: 'API 響應時間、錯誤率、吞吐量等服務指標。', owner: 'SRE 平台團隊', created_at: '2025-09-18T16:45:00Z', updated_at: '2025-09-18T16:45:00Z', path: '/dashboard/api-service-status', grafana_url: `${DEFAULT_GRAFANA_BASE_URL}/d/aead3d54-423b-4a91-b91c-dbdf40d7fff5`, grafana_dashboard_uid: 'aead3d54-423b-4a91-b91c-dbdf40d7fff5', grafana_folder_uid: 'biz-folder' },
+    { id: 'user-experience-monitoring', name: '用戶體驗監控', type: 'grafana', category: '營運與容量', description: '頁面載入時間、用戶行為分析、錯誤追蹤。', owner: '前端團隊', created_at: '2025-09-18T17:00:00Z', updated_at: '2025-09-18T17:00:00Z', path: '/dashboard/user-experience-monitoring', grafana_url: `${DEFAULT_GRAFANA_BASE_URL}/d/another-dashboard-id-for-ux`, grafana_dashboard_uid: 'another-dashboard-id-for-ux', grafana_folder_uid: 'ux-folder' },
     {
         id: 'custom-built-in-1',
         name: 'My Custom Dashboard',
@@ -1172,8 +1172,8 @@ const MOCK_DASHBOARDS: Dashboard[] = [
     },
 ];
 const MOCK_AVAILABLE_GRAFANA_DASHBOARDS = [
-    { uid: 'grafana-uid-1', title: 'Service Health', url: `${DEFAULT_GRAFANA_BASE_URL}/d/grafana-uid-1`, folderTitle: 'Production', folderUid: 'prod-folder' },
-    { uid: 'grafana-uid-2', title: 'Kubernetes Cluster', url: `${DEFAULT_GRAFANA_BASE_URL}/d/grafana-uid-2`, folderTitle: 'Infrastructure', folderUid: 'infra-folder' },
+    { uid: 'grafana-uid-1', title: 'Service Health', url: `${DEFAULT_GRAFANA_BASE_URL}/d/grafana-uid-1`, folder_title: 'Production', folder_uid: 'prod-folder' },
+    { uid: 'grafana-uid-2', title: 'Kubernetes Cluster', url: `${DEFAULT_GRAFANA_BASE_URL}/d/grafana-uid-2`, folder_title: 'Infrastructure', folder_uid: 'infra-folder' },
 ];
 const MOCK_DASHBOARD_TEMPLATES: DashboardTemplate[] = [
     { id: 'tpl-001', name: '微服務健康度', description: '監控單一微服務，包括延遲、流量、錯誤率與資源飽和度。適用於 API 服務、後端服務監控。', icon: 'server', category: '應用程式' },
@@ -1202,7 +1202,7 @@ const MOCK_ALERT_RULE_DEFAULT: Partial<AlertRule> = {
                     metric: 'cpu_usage_percent',
                     operator: '>',
                     threshold: 80,
-                    durationMinutes: 5,
+                    duration_minutes: 5,
                 },
             ],
         },
@@ -1235,7 +1235,7 @@ const MOCK_ALERT_RULES: AlertRule[] = [
             resource: 'web-prod-12',
         },
         target_resource_ids: ['res-001', 'res-003', 'res-004'],  // 新增：關聯的資源 ID
-        targetScope: 'specific'  // 新增：目標範圍
+        target_scope: 'specific'  // 新增：目標範圍
     },
     {
         id: 'rule-002',
@@ -1256,7 +1256,7 @@ const MOCK_ALERT_RULES: AlertRule[] = [
             resource: 'api-gateway-prod',
         },
         target_resource_ids: ['res-001'],  // 新增：關聯的資源 ID
-        targetScope: 'specific'  // 新增：目標範圍
+        target_scope: 'specific'  // 新增：目標範圍
     },
 ];
 const MOCK_ALERT_RULE_TEMPLATES: AlertRuleTemplate[] = [
@@ -1264,11 +1264,11 @@ const MOCK_ALERT_RULE_TEMPLATES: AlertRuleTemplate[] = [
         id: 'art-001',
         name: 'High CPU Usage',
         description: 'Monitors CPU usage and alerts when it exceeds a threshold for a specified duration.',
-        resourceType: 'host',
+        resource_type: 'host',
         data: {
             name: 'High CPU Usage on Prod Hosts',
             description: 'Monitors CPU usage on production hosts and alerts when it exceeds 90% for 5 minutes.',
-            condition_groups: [{ logic: 'OR', severity: 'warning', conditions: [{ metric: 'cpu_usage_percent', operator: '>', threshold: 90, durationMinutes: 5 }] }],
+            condition_groups: [{ logic: 'OR', severity: 'warning', conditions: [{ metric: 'cpu_usage_percent', operator: '>', threshold: 90, duration_minutes: 5 }] }],
             title_template: '[{{severity}}] High CPU on {{resource.name}}',
             content_template: 'CPU usage is at {{value}}%, exceeding the threshold of {{threshold}}% for {{duration}} minutes.',
             automation: { enabled: true, script_id: 'play-002' }
@@ -1283,11 +1283,11 @@ const MOCK_ALERT_RULE_TEMPLATES: AlertRuleTemplate[] = [
         id: 'art-002',
         name: 'Low Disk Space',
         description: 'Alerts when available disk space is critically low.',
-        resourceType: 'host',
+        resource_type: 'host',
         data: {
             name: 'Low Disk Space',
             description: 'Alerts when disk space is critically low.',
-            condition_groups: [{ logic: 'OR', severity: 'critical', conditions: [{ metric: 'disk_free_percent', operator: '<', threshold: 10, durationMinutes: 15 }] }],
+            condition_groups: [{ logic: 'OR', severity: 'critical', conditions: [{ metric: 'disk_free_percent', operator: '<', threshold: 10, duration_minutes: 15 }] }],
             title_template: '[{{severity}}] Low Disk Space on {{resource.name}}',
             content_template: 'Disk space is at {{value}}%, which is below the threshold of {{threshold}}%.'
         },
@@ -1300,11 +1300,11 @@ const MOCK_ALERT_RULE_TEMPLATES: AlertRuleTemplate[] = [
         id: 'art-003',
         name: 'DB Connection Error',
         description: 'Alerts when database connection attempts are failing.',
-        resourceType: 'database',
+        resource_type: 'database',
         data: {
             name: 'Database Connection Failures',
             description: 'Triggers when the rate of DB connection failures exceeds 5%.',
-            condition_groups: [{ logic: 'OR', severity: 'critical', conditions: [{ metric: 'db_connection_error_rate', operator: '>', threshold: 5, durationMinutes: 2 }] }],
+            condition_groups: [{ logic: 'OR', severity: 'critical', conditions: [{ metric: 'db_connection_error_rate', operator: '>', threshold: 5, duration_minutes: 2 }] }],
             title_template: '[{{severity}}] DB Connection Errors on {{resource.name}}',
             content_template: 'Database connection error rate is at {{value}}%, exceeding the threshold of {{threshold}}%.'
         },
@@ -1327,7 +1327,7 @@ const MOCK_SILENCE_RULE_OPTIONS: SilenceRuleOptions = {
         severity: ['critical', 'warning', 'info'],
         env: ['production', 'staging', 'development'],
     },
-    defaultMatcher: { key: 'env' as const, operator: '=' as const, value: 'staging' },
+    default_matcher: { key: 'env' as const, operator: '=' as const, value: 'staging' },
     weekdays: [
         { value: 0, label: '日' }, { value: 1, label: '一' }, { value: 2, label: '二' },
         { value: 3, label: '三' }, { value: 4, label: '四' }, { value: 5, label: '五' },
@@ -1342,7 +1342,7 @@ const MOCK_SILENCE_RULE_OPTIONS: SilenceRuleOptions = {
         { value: true, label: 'Enabled' },
         { value: false, label: 'Disabled' }
     ],
-    recurrenceTypes: [
+    recurrence_types: [
         { value: 'daily', label: '每日' },
         { value: 'weekly', label: '每週' },
         { value: 'monthly', label: '每月' },
@@ -1357,28 +1357,28 @@ const MOCK_RESOURCES: Resource[] = [
     { id: 'res-007', name: 'api-service', status: 'warning', type: 'Kubernetes Service', provider: 'AWS', region: 'us-east-1', owner: 'API Services', last_check_in_at: new Date(Date.now() - 60 * 1000).toISOString(), created_at: '2024-01-10T10:00:00Z', updated_at: '2024-01-15T11:00:00Z' },
 ];
 const MOCK_RESOURCE_GROUPS: ResourceGroup[] = [
-    { id: 'rg-001', name: '正式環境 Web 伺服器', description: '所有面向正式環境的 Web 伺服器', ownerTeam: 'Web Team', member_ids: ['res-004'], statusSummary: { healthy: 12, warning: 1, critical: 0 }, created_at: '2024-01-12T10:00:00Z', updated_at: '2024-01-12T10:00:00Z' },
-    { id: 'rg-002', name: '核心資料庫', description: '核心服務的主資料庫與副本資料庫', ownerTeam: 'DBA Team', member_ids: ['res-002'], statusSummary: { healthy: 8, warning: 0, critical: 1 }, created_at: '2024-01-12T10:00:00Z', updated_at: '2024-01-12T10:00:00Z' },
-    { id: 'rg-003', name: 'API 服務', description: '主要 API 的所有微服務', ownerTeam: 'API Team', member_ids: ['res-007'], statusSummary: { healthy: 25, warning: 3, critical: 2 }, created_at: '2024-01-12T10:00:00Z', updated_at: '2024-01-12T10:00:00Z' },
+    { id: 'rg-001', name: '正式環境 Web 伺服器', description: '所有面向正式環境的 Web 伺服器', owner_team: 'Web Team', member_ids: ['res-004'], status_summary: { healthy: 12, warning: 1, critical: 0 }, created_at: '2024-01-12T10:00:00Z', updated_at: '2024-01-12T10:00:00Z' },
+    { id: 'rg-002', name: '核心資料庫', description: '核心服務的主資料庫與副本資料庫', owner_team: 'DBA Team', member_ids: ['res-002'], status_summary: { healthy: 8, warning: 0, critical: 1 }, created_at: '2024-01-12T10:00:00Z', updated_at: '2024-01-12T10:00:00Z' },
+    { id: 'rg-003', name: 'API 服務', description: '主要 API 的所有微服務', owner_team: 'API Team', member_ids: ['res-007'], status_summary: { healthy: 25, warning: 3, critical: 2 }, created_at: '2024-01-12T10:00:00Z', updated_at: '2024-01-12T10:00:00Z' },
 ];
 const MOCK_RESOURCE_OVERVIEW_DATA: ResourceOverviewData = {
-    distributionByType: [
+    distribution_by_type: [
         { value: 150, name: 'EC2 Instance' },
         { value: 80, name: 'Kubernetes Pod' },
         { value: 50, name: 'RDS Database' },
         { value: 40, name: 'API Gateway' },
         { value: 25, name: 'Other' },
     ],
-    distributionByProvider: [
+    distribution_by_provider: [
         { provider: 'AWS', count: 250 },
         { provider: 'GCP', count: 80 },
         { provider: 'Azure', count: 15 },
     ],
-    recentlyDiscovered: [
-        { id: 'disc-001', name: '10.1.5.23', type: 'VM', discoveredAt: '5m ago', jobId: 'dj-003' },
-        { id: 'disc-002', name: 'redis-cache-xyz', type: 'Kubernetes Pod', discoveredAt: '1h ago', jobId: 'dj-001' },
+    recently_discovered: [
+        { id: 'disc-001', name: '10.1.5.23', type: 'VM', discovered_at: '5m ago', job_id: 'dj-003' },
+        { id: 'disc-002', name: 'redis-cache-xyz', type: 'Kubernetes Pod', discovered_at: '1h ago', job_id: 'dj-001' },
     ],
-    groupsWithMostAlerts: [
+    groups_with_most_alerts: [
         { id: 'rg-003', name: 'API Services', criticals: 2, warnings: 3 },
         { id: 'rg-002', name: 'Core Databases', criticals: 1, warnings: 0 },
         { id: 'rg-001', name: 'Production Web Servers', criticals: 0, warnings: 1 },
@@ -1386,7 +1386,7 @@ const MOCK_RESOURCE_OVERVIEW_DATA: ResourceOverviewData = {
 };
 const MOCK_PLAYBOOKS: AutomationPlaybook[] = [
     { id: 'play-001', name: '重啟故障 Pod', description: '自動重啟處於 CrashLoopBackOff 狀態的 Pod。', trigger: 'K8s 告警', last_run_at: new Date(Date.now() - 5 * 60 * 1000).toISOString(), last_run_status: 'success', run_count: 12, type: 'shell', content: '#!/bin/bash...', parameters: [{ name: 'namespace', label: '命名空間', type: 'string', required: true }], created_at: '2025-09-20T10:00:00Z', updated_at: '2025-09-23T12:00:00Z' },
-    { id: 'play-002', name: '擴展 Web 層', description: '向 Web 伺服器自動擴展組增加更多 EC2 實例。', trigger: '高 CPU', last_run_at: new Date(Date.now() - 60 * 60 * 1000).toISOString(), last_run_status: 'success', run_count: 3, type: 'python', content: 'import boto3...', parameters: [{ name: 'instance_count', label: '實例數量', type: 'number', required: true, defaultValue: 2 }], created_at: '2025-09-21T11:00:00Z', updated_at: '2025-09-22T13:00:00Z' },
+    { id: 'play-002', name: '擴展 Web 層', description: '向 Web 伺服器自動擴展組增加更多 EC2 實例。', trigger: '高 CPU', last_run_at: new Date(Date.now() - 60 * 60 * 1000).toISOString(), last_run_status: 'success', run_count: 3, type: 'python', content: 'import boto3...', parameters: [{ name: 'instance_count', label: '實例數量', type: 'number', required: true, default_value: 2 }], created_at: '2025-09-21T11:00:00Z', updated_at: '2025-09-22T13:00:00Z' },
 ];
 const MOCK_AUTOMATION_EXECUTIONS: AutomationExecution[] = [
     {
@@ -1402,8 +1402,8 @@ const MOCK_AUTOMATION_EXECUTIONS: AutomationExecution[] = [
         parameters: { namespace: 'production' },
         logs: { stdout: 'Successfully restarted pod.', stderr: '' },
         incident_id: 'INC-002',           // 新增：關聯事件 ID
-        triggeredByRuleId: 'rule-002',   // 新增：關聯規則 ID
-        targetResourceId: 'res-002'      // 新增：關聯資源 ID
+        alert_rule_id: 'rule-002',          // 新增：關聯規則 ID
+        target_resource_id: 'res-002'      // 新增：關聯資源 ID
     },
 ];
 const MOCK_AUTOMATION_TRIGGERS: AutomationTrigger[] = [
@@ -1424,7 +1424,7 @@ const MOCK_TEAMS: Team[] = [
 ];
 const MOCK_ROLES: Role[] = [
     {
-        id: 'role-001', name: 'Administrator', description: '擁有所有權限', userCount: 1, enabled: true, created_at: '2024-01-01T09:00:00Z', updated_at: '2024-01-01T09:00:00Z', permissions: [
+        id: 'role-001', name: 'Administrator', description: '擁有所有權限', user_count: 1, enabled: true, created_at: '2024-01-01T09:00:00Z', updated_at: '2024-01-01T09:00:00Z', permissions: [
             { module: 'Incidents', actions: ['read', 'create', 'update', 'delete'] },
             { module: 'Resources', actions: ['read', 'create', 'update', 'delete'] },
             { module: 'Automation', actions: ['read', 'create', 'update', 'delete', 'execute'] },
@@ -1432,14 +1432,14 @@ const MOCK_ROLES: Role[] = [
         ]
     },
     {
-        id: 'role-002', name: 'SRE Engineer', description: '擁有事件、資源、自動化管理權限', userCount: 1, enabled: true, created_at: '2024-01-01T09:00:00Z', updated_at: '2024-01-01T09:00:00Z', permissions: [
+        id: 'role-002', name: 'SRE Engineer', description: '擁有事件、資源、自動化管理權限', user_count: 1, enabled: true, created_at: '2024-01-01T09:00:00Z', updated_at: '2024-01-01T09:00:00Z', permissions: [
             { module: 'Incidents', actions: ['read', 'update'] },
             { module: 'Resources', actions: ['read', 'update'] },
             { module: 'Automation', actions: ['read', 'execute'] },
         ]
     },
     {
-        id: 'role-003', name: 'Developer', description: '擁有應用程式開發相關權限', userCount: 2, enabled: true, created_at: '2024-01-01T09:00:00Z', updated_at: '2024-01-01T09:00:00Z', permissions: [
+        id: 'role-003', name: 'Developer', description: '擁有應用程式開發相關權限', user_count: 2, enabled: true, created_at: '2024-01-01T09:00:00Z', updated_at: '2024-01-01T09:00:00Z', permissions: [
             { module: 'Incidents', actions: ['read'] },
             { module: 'Resources', actions: ['read'] },
         ]
@@ -1456,37 +1456,37 @@ const MOCK_AUDIT_LOGS: AuditLog[] = [
 ];
 const MOCK_TAG_DEFINITIONS: TagDefinition[] = createTagDefinitions();
 const MOCK_NOTIFICATIONS: NotificationItem[] = [
-    { id: 'notif-1', title: 'Critical: DB CPU > 95%', description: 'The production database is under heavy load.', severity: 'critical', status: 'unread', created_at: new Date(Date.now() - 60000 * 5).toISOString(), linkUrl: '/incidents/INC-002' },
+    { id: 'notif-1', title: 'Critical: DB CPU > 95%', description: 'The production database is under heavy load.', severity: 'critical', status: 'unread', created_at: new Date(Date.now() - 60000 * 5).toISOString(), link_url: '/incidents/INC-002' },
 ];
 const MOCK_NOTIFICATION_STRATEGIES: NotificationStrategy[] = [
     {
         id: 'strat-1',
         name: 'Critical Database Alerts',
         enabled: true,
-        triggerCondition: 'severity = Critical AND service = api-gateway',
-        channelCount: 2,
-        severityLevels: ['Critical'],
-        impactLevels: ['High'],
+        trigger_condition: 'severity = Critical AND service = api-gateway',
+        channel_count: 2,
+        severity_levels: ['Critical'],
+        impact_levels: ['High'],
         creator: 'Admin',
         created_at: '2025-09-20T10:00:00Z',
         updated_at: '2025-09-20T10:00:00Z'
     }
 ];
 const MOCK_NOTIFICATION_STRATEGY_OPTIONS: NotificationStrategyOptions = {
-    severityLevels: ['Critical', 'Warning', 'Info'],
-    impactLevels: ['High', 'Medium', 'Low'],
-    defaultCondition: 'severity = Critical',
-    conditionKeys: {
+    severity_levels: ['Critical', 'Warning', 'Info'],
+    impact_levels: ['High', 'Medium', 'Low'],
+    default_condition: 'severity = Critical',
+    condition_keys: {
         severity: ['Critical', 'Warning', 'Info'],
         impact: ['High', 'Medium', 'Low'],
         service: ['api-gateway', 'payment-service']
     },
-    tagKeys: ['env', 'service'],
-    tagValues: {
+    tag_keys: ['env', 'service'],
+    tag_values: {
         env: ['production', 'staging', 'development'],
         service: ['api-gateway', 'payment-service']
     },
-    stepTitles: ["基本資訊", "通知管道", "匹配條件"],
+    step_titles: ["基本資訊", "通知管道", "匹配條件"],
 };
 const MOCK_NOTIFICATION_CHANNELS: NotificationChannel[] = [
     {
@@ -1499,7 +1499,7 @@ const MOCK_NOTIFICATION_CHANNELS: NotificationChannel[] = [
             cc: 'sre-manager@example.com,dev-lead@example.com',
             bcc: 'audit@example.com'
         },
-        lastTestResult: 'success',
+        last_test_result: 'success',
         last_tested_at: '2025-09-22T11:00:00Z',
         created_at: '2025-09-21T09:00:00Z',
         updated_at: '2025-09-22T11:00:00Z'
@@ -1507,10 +1507,10 @@ const MOCK_NOTIFICATION_CHANNELS: NotificationChannel[] = [
 ];
 const MOCK_NOTIFICATION_OPTIONS: NotificationOptions = {
     severities: [
-        { value: 'critical', label: '嚴重', className: 'bg-red-950/40 border border-red-500/40 text-red-300 backdrop-blur-sm shadow-sm' },
-        { value: 'warning', label: '警告', className: 'bg-amber-950/40 border border-amber-500/40 text-amber-300 backdrop-blur-sm shadow-sm' },
-        { value: 'info', label: '資訊', className: 'bg-sky-950/40 border border-sky-500/40 text-sky-300 backdrop-blur-sm shadow-sm' },
-        { value: 'success', label: '成功', className: 'bg-emerald-950/40 border border-emerald-500/40 text-emerald-300 backdrop-blur-sm shadow-sm' },
+        { value: 'critical', label: '嚴重', class_name: 'bg-red-950/40 border border-red-500/40 text-red-300 backdrop-blur-sm shadow-sm' },
+        { value: 'warning', label: '警告', class_name: 'bg-amber-950/40 border border-amber-500/40 text-amber-300 backdrop-blur-sm shadow-sm' },
+        { value: 'info', label: '資訊', class_name: 'bg-sky-950/40 border border-sky-500/40 text-sky-300 backdrop-blur-sm shadow-sm' },
+        { value: 'success', label: '成功', class_name: 'bg-emerald-950/40 border border-emerald-500/40 text-emerald-300 backdrop-blur-sm shadow-sm' },
     ],
 };
 const MOCK_NOTIFICATION_CHANNEL_ICONS = {
@@ -1522,13 +1522,13 @@ const MOCK_NOTIFICATION_CHANNEL_ICONS = {
     'Default': { icon: 'bell', color: 'text-slate-400' }
 };
 const MOCK_NOTIFICATION_HISTORY: NotificationHistoryRecord[] = [
-    { id: 'nh-1', timestamp: '2025-09-23T14:05:10Z', strategy: 'Critical Database Alerts', channel: 'SRE On-call Email', channelType: 'Email', recipient: 'sre-team@example.com', status: 'success', content: 'DB CPU > 95%' },
+    { id: 'nh-1', timestamp: '2025-09-23T14:05:10Z', strategy: 'Critical Database Alerts', channel: 'SRE On-call Email', channel_type: 'Email', recipient: 'sre-team@example.com', status: 'success', content: 'DB CPU > 95%' },
 ];
 const MOCK_LOGIN_HISTORY: LoginHistoryRecord[] = [
     { id: 'lh-1', timestamp: '2025-09-23T10:00:00Z', ip: '192.168.1.1', device: 'Chrome on macOS', status: 'success' },
 ];
 const MOCK_LOGS: LogEntry[] = [
-    { id: 'log-1', timestamp: new Date().toISOString(), level: 'error', service: 'payment-service', message: 'Failed to process payment', details: { transactionId: 'txn-123' } },
+    { id: 'log-1', timestamp: new Date().toISOString(), level: 'error', service: 'payment-service', message: 'Failed to process payment', details: { transaction_id: 'txn-123' } },
 ];
 const MOCK_LOG_TIME_OPTIONS: { label: string, value: string }[] = [
     { label: '最近 15 分鐘', value: '15m' },
@@ -1536,138 +1536,138 @@ const MOCK_LOG_TIME_OPTIONS: { label: string, value: string }[] = [
     { label: '最近 4 小時', value: '4h' },
     { label: '最近 1 天', value: '1d' },
 ];
-const MOCK_MAIL_SETTINGS: MailSettings = { smtpServer: 'smtp.example.com', port: 587, username: 'noreply@sre.platform', senderName: 'SRE Platform', senderEmail: 'noreply@sre.platform', encryption: 'tls' };
-const MOCK_GRAFANA_SETTINGS: GrafanaSettings = { enabled: true, url: DEFAULT_GRAFANA_BASE_URL, apiKey: 'glsa_xxxxxxxxxxxxxxxxxxxxxxxx', orgId: 1 };
+const MOCK_MAIL_SETTINGS: MailSettings = { smtp_server: 'smtp.example.com', port: 587, username: 'noreply@sre.platform', sender_name: 'SRE Platform', sender_email: 'noreply@sre.platform', encryption: 'tls' };
+const MOCK_GRAFANA_SETTINGS: GrafanaSettings = { enabled: true, url: DEFAULT_GRAFANA_BASE_URL, api_key: 'glsa_xxxxxxxxxxxxxxxxxxxxxxxx', org_id: 1 };
 const MOCK_GRAFANA_OPTIONS: GrafanaOptions = {
-    timeOptions: [{ label: 'Last 6 hours', value: 'from=now-6h&to=now' }, { label: 'Last 24 hours', value: 'from=now-24h&to=now' }],
-    refreshOptions: [{ label: '1m', value: '1m' }, { label: '5m', value: '5m' }],
-    tvModeOptions: [{ label: 'Off', value: 'off' }, { label: 'On', value: 'on' }],
-    themeOptions: [{ label: '深色', value: 'dark' }, { label: '淺色', value: 'light' }],
-    themeLabel: '主題',
-    tvModeLabel: 'TV 模式',
-    refreshLabel: '刷新',
-    timeLabel: '時間',
+    time_options: [{ label: 'Last 6 hours', value: 'from=now-6h&to=now' }, { label: 'Last 24 hours', value: 'from=now-24h&to=now' }],
+    refresh_options: [{ label: '1m', value: '1m' }, { label: '5m', value: '5m' }],
+    tv_mode_options: [{ label: 'Off', value: 'off' }, { label: 'On', value: 'on' }],
+    theme_options: [{ label: '深色', value: 'dark' }, { label: '淺色', value: 'light' }],
+    theme_label: '主題',
+    tv_mode_label: 'TV 模式',
+    refresh_label: '刷新',
+    time_label: '時間',
 };
-const MOCK_AUTH_SETTINGS: AuthSettings = { provider: 'Keycloak', enabled: true, clientId: 'sre-platform-client', clientSecret: '...', realm: 'sre', authUrl: '...', tokenUrl: '...', userInfoUrl: '...', idpAdminUrl: DEFAULT_IDP_ADMIN_URL };
+const MOCK_AUTH_SETTINGS: AuthSettings = { provider: 'Keycloak', enabled: true, client_id: 'sre-platform-client', client_secret: '...', realm: 'sre', auth_url: '...', token_url: '...', user_info_url: '...', idp_admin_url: DEFAULT_IDP_ADMIN_URL };
 const LAYOUT_WIDGETS: LayoutWidget[] = [
     // Incident Management
-    { id: 'incident_pending_count', name: '待處理事件', description: '顯示目前狀態為「新」的事件總數。', supportedPages: ['事件'] },
-    { id: 'incident_in_progress', name: '處理中事件', description: '顯示目前狀態為「已認領」的事件總數。', supportedPages: ['事件'] },
-    { id: 'incident_resolved_today', name: '今日已解決', description: '顯示今天已解決的事件總數。', supportedPages: ['事件'] },
+    { id: 'incident_pending_count', name: '待處理事件', description: '顯示目前狀態為「新」的事件總數。', supported_pages: ['事件'] },
+    { id: 'incident_in_progress', name: '處理中事件', description: '顯示目前狀態為「已認領」的事件總數。', supported_pages: ['事件'] },
+    { id: 'incident_resolved_today', name: '今日已解決', description: '顯示今天已解決的事件總數。', supported_pages: ['事件'] },
     // SREWarRoom
-    { id: 'sre_pending_incidents', name: '待處理事件', description: '顯示待處理的事件總數。', supportedPages: ['SREWarRoom'] },
-    { id: 'sre_in_progress', name: '處理中', description: '顯示正在處理中的事件。', supportedPages: ['SREWarRoom'] },
-    { id: 'sre_resolved_today', name: '今日已解決', description: '顯示今日已解決的事件。', supportedPages: ['SREWarRoom'] },
-    { id: 'sre_automation_rate', name: '自動化率', description: '顯示自動化處理的事件比例。', supportedPages: ['SREWarRoom'] },
+    { id: 'sre_pending_incidents', name: '待處理事件', description: '顯示待處理的事件總數。', supported_pages: ['SREWarRoom'] },
+    { id: 'sre_in_progress', name: '處理中', description: '顯示正在處理中的事件。', supported_pages: ['SREWarRoom'] },
+    { id: 'sre_resolved_today', name: '今日已解決', description: '顯示今日已解決的事件。', supported_pages: ['SREWarRoom'] },
+    { id: 'sre_automation_rate', name: '自動化率', description: '顯示自動化處理的事件比例。', supported_pages: ['SREWarRoom'] },
     // InfrastructureInsights
-    { id: 'infra_total_resources', name: '總資源數', description: '顯示所有監控的資源總數。', supportedPages: ['InfrastructureInsights'] },
-    { id: 'infra_running', name: '運行中', description: '顯示當前運行中的資源數量。', supportedPages: ['InfrastructureInsights'] },
-    { id: 'infra_anomalies', name: '異常', description: '顯示存在異常狀態的資源數量。', supportedPages: ['InfrastructureInsights'] },
-    { id: 'infra_offline', name: '離線', description: '顯示當前離線的資源數量。', supportedPages: ['InfrastructureInsights'] },
+    { id: 'infra_total_resources', name: '總資源數', description: '顯示所有監控的資源總數。', supported_pages: ['InfrastructureInsights'] },
+    { id: 'infra_running', name: '運行中', description: '顯示當前運行中的資源數量。', supported_pages: ['InfrastructureInsights'] },
+    { id: 'infra_anomalies', name: '異常', description: '顯示存在異常狀態的資源數量。', supported_pages: ['InfrastructureInsights'] },
+    { id: 'infra_offline', name: '離線', description: '顯示當前離線的資源數量。', supported_pages: ['InfrastructureInsights'] },
 
     // NEW WIDGETS START HERE
     // Resource Management
-    { id: 'resource_total_count', name: '資源總數', description: '顯示所有已註冊的資源總數。', supportedPages: ['資源', 'ResourceOverview'] },
-    { id: 'resource_health_rate', name: '資源健康率', description: '處於健康狀態的資源百分比。', supportedPages: ['資源', 'ResourceOverview'] },
-    { id: 'resource_alerting', name: '告警中資源', description: '目前處於警告或嚴重狀態的資源數。', supportedPages: ['資源', 'ResourceOverview'] },
-    { id: 'resource_group_count', name: '資源群組總數', description: '平台中所有資源群組的數量。', supportedPages: ['ResourceOverview'] },
+    { id: 'resource_total_count', name: '資源總數', description: '顯示所有已註冊的資源總數。', supported_pages: ['資源', 'ResourceOverview'] },
+    { id: 'resource_health_rate', name: '資源健康率', description: '處於健康狀態的資源百分比。', supported_pages: ['資源', 'ResourceOverview'] },
+    { id: 'resource_alerting', name: '告警中資源', description: '目前處於警告或嚴重狀態的資源數。', supported_pages: ['資源', 'ResourceOverview'] },
+    { id: 'resource_group_count', name: '資源群組總數', description: '平台中所有資源群組的數量。', supported_pages: ['ResourceOverview'] },
 
     // Dashboard Management
-    { id: 'dashboard_total_count', name: '儀表板總數', description: '平台中所有儀表板的數量。', supportedPages: ['儀表板'] },
-    { id: 'dashboard_custom_count', name: '自訂儀表板', description: '使用者自訂的內建儀表板數量。', supportedPages: ['儀表板'] },
-    { id: 'dashboard_grafana_count', name: 'Grafana 儀表板', description: '從 Grafana 連結的儀表板數量。', supportedPages: ['儀表板'] },
+    { id: 'dashboard_total_count', name: '儀表板總數', description: '平台中所有儀表板的數量。', supported_pages: ['儀表板'] },
+    { id: 'dashboard_custom_count', name: '自訂儀表板', description: '使用者自訂的內建儀表板數量。', supported_pages: ['儀表板'] },
+    { id: 'dashboard_grafana_count', name: 'Grafana 儀表板', description: '從 Grafana 連結的儀表板數量。', supported_pages: ['儀表板'] },
 
     // Analysis Center
-    { id: 'analysis_critical_anomalies', name: '嚴重異常 (24H)', description: '過去 24 小時内偵測到的嚴重異常事件。', supportedPages: ['智慧排查'] },
-    { id: 'analysis_log_volume', name: '日誌量 (24H)', description: '過去 24 小時的總日誌量。', supportedPages: ['智慧排查'] },
-    { id: 'analysis_trace_errors', name: '追蹤錯誤率', description: '包含錯誤的追蹤佔比。', supportedPages: ['智慧排查'] },
+    { id: 'analysis_critical_anomalies', name: '嚴重異常 (24H)', description: '過去 24 小時内偵測到的嚴重異常事件。', supported_pages: ['智慧排查'] },
+    { id: 'analysis_log_volume', name: '日誌量 (24H)', description: '過去 24 小時的總日誌量。', supported_pages: ['智慧排查'] },
+    { id: 'analysis_trace_errors', name: '追蹤錯誤率', description: '包含錯誤的追蹤佔比。', supported_pages: ['智慧排查'] },
 
     // Automation Center
-    { id: 'automation_runs_today', name: '今日運行次數', description: '所有自動化腳本今日的總運行次數。', supportedPages: ['自動化'] },
-    { id: 'automation_success_rate', name: '成功率', description: '自動化腳本的整體執行成功率。', supportedPages: ['自動化'] },
-    { id: 'automation_suppressed_alerts', name: '已抑制告警', description: '因自動化成功執行而抑制的告警數。', supportedPages: ['自動化'] },
+    { id: 'automation_runs_today', name: '今日運行次數', description: '所有自動化腳本今日的總運行次數。', supported_pages: ['自動化'] },
+    { id: 'automation_success_rate', name: '成功率', description: '自動化腳本的整體執行成功率。', supported_pages: ['自動化'] },
+    { id: 'automation_suppressed_alerts', name: '已抑制告警', description: '因自動化成功執行而抑制的告警數。', supported_pages: ['自動化'] },
 
     // IAM
-    { id: 'iam_total_users', name: '使用者總數', description: '平台中的總使用者帳號數。', supportedPages: ['身份與存取管理'] },
-    { id: 'iam_active_users', name: '活躍使用者', description: '過去 7 天内有登入活動的使用者。', supportedPages: ['身份與存取管理'] },
-    { id: 'iam_login_failures', name: '登入失敗 (24H)', description: '過去 24 小時內的登入失敗次數。', supportedPages: ['身份與存取管理'] },
+    { id: 'iam_total_users', name: '使用者總數', description: '平台中的總使用者帳號數。', supported_pages: ['身份與存取管理'] },
+    { id: 'iam_active_users', name: '活躍使用者', description: '過去 7 天内有登入活動的使用者。', supported_pages: ['身份與存取管理'] },
+    { id: 'iam_login_failures', name: '登入失敗 (24H)', description: '過去 24 小時內的登入失敗次數。', supported_pages: ['身份與存取管理'] },
 
     // Notification Management
-    { id: 'notification_sent_today', name: '今日已發送', description: '今日透過所有管道發送的通知總數。', supportedPages: ['通知'] },
-    { id: 'notification_failure_rate', name: '發送失敗率', description: '通知發送的整體失敗率。', supportedPages: ['通知'] },
-    { id: 'notification_channels', name: '啟用中管道', description: '目前已啟用並可用的通知管道數。', supportedPages: ['通知'] },
+    { id: 'notification_sent_today', name: '今日已發送', description: '今日透過所有管道發送的通知總數。', supported_pages: ['通知'] },
+    { id: 'notification_failure_rate', name: '發送失敗率', description: '通知發送的整體失敗率。', supported_pages: ['通知'] },
+    { id: 'notification_channels', name: '啟用中管道', description: '目前已啟用並可用的通知管道數。', supported_pages: ['通知'] },
 
     // Platform Settings
-    { id: 'platform_tags_defined', name: '標籤總數', description: '平台中定義的標籤鍵總數。', supportedPages: ['平台'] },
-    { id: 'platform_auth_provider', name: '認證提供商', description: '目前使用的身份驗證提供商。', supportedPages: ['平台'] },
-    { id: 'platform_mail_status', name: '郵件服務狀態', description: '郵件發送服務的健康狀態。', supportedPages: ['平台'] },
+    { id: 'platform_tags_defined', name: '標籤總數', description: '平台中定義的標籤鍵總數。', supported_pages: ['平台'] },
+    { id: 'platform_auth_provider', name: '認證提供商', description: '目前使用的身份驗證提供商。', supported_pages: ['平台'] },
+    { id: 'platform_mail_status', name: '郵件服務狀態', description: '郵件發送服務的健康狀態。', supported_pages: ['平台'] },
 
     // Personal Settings
-    { id: 'profile_login_count_7d', name: '最近 7 日登入次數', description: '過去 7 天內的成功登入次數。', supportedPages: ['個人設定'] },
-    { id: 'profile_last_password_change', name: '上次密碼變更', description: '您的密碼上次更新的時間。', supportedPages: ['個人設定'] },
-    { id: 'profile_mfa_status', name: 'MFA 狀態', description: '多因素驗證 (MFA) 的啟用狀態。', supportedPages: ['個人設定'] },
+    { id: 'profile_login_count_7d', name: '最近 7 日登入次數', description: '過去 7 天內的成功登入次數。', supported_pages: ['個人設定'] },
+    { id: 'profile_last_password_change', name: '上次密碼變更', description: '您的密碼上次更新的時間。', supported_pages: ['個人設定'] },
+    { id: 'profile_mfa_status', name: 'MFA 狀態', description: '多因素驗證 (MFA) 的啟用狀態。', supported_pages: ['個人設定'] },
 ];
-const DEFAULT_LAYOUTS: Record<string, { widgetIds: string[]; updated_at: string; updatedBy: string; }> = {
-    "SREWarRoom": { widgetIds: ['sre_pending_incidents', 'sre_in_progress', 'sre_resolved_today', 'sre_automation_rate'], updated_at: '2025-09-24T10:30:00Z', updatedBy: 'Admin User' },
-    "InfrastructureInsights": { widgetIds: ['infra_total_resources', 'infra_running', 'infra_anomalies', 'infra_offline'], updated_at: '2025-09-24T10:30:00Z', updatedBy: 'Admin User' },
-    "事件": { widgetIds: ['incident_pending_count', 'incident_in_progress', 'incident_resolved_today'], updated_at: '2025-09-24T10:30:00Z', updatedBy: 'Admin User' },
-    "資源": { widgetIds: ['resource_total_count', 'resource_health_rate', 'resource_alerting'], updated_at: '2025-09-24T10:30:00Z', updatedBy: 'Admin User' },
-    "ResourceOverview": { widgetIds: ['resource_total_count', 'resource_health_rate', 'resource_alerting', 'resource_group_count'], updated_at: '2025-09-24T10:30:00Z', updatedBy: 'Admin User' },
-    "儀表板": { widgetIds: ['dashboard_total_count', 'dashboard_custom_count', 'dashboard_grafana_count'], updated_at: '2025-09-24T10:30:00Z', updatedBy: 'Admin User' },
-    "智慧排查": { widgetIds: ['analysis_critical_anomalies', 'analysis_log_volume', 'analysis_trace_errors'], updated_at: '2025-09-24T10:30:00Z', updatedBy: 'Admin User' },
-    "自動化": { widgetIds: ['automation_runs_today', 'automation_success_rate', 'automation_suppressed_alerts'], updated_at: '2025-09-24T10:30:00Z', updatedBy: 'Admin User' },
-    "身份與存取管理": { widgetIds: ['iam_total_users', 'iam_active_users', 'iam_login_failures'], updated_at: '2025-09-24T10:30:00Z', updatedBy: 'Admin User' },
-    "通知": { widgetIds: ['notification_sent_today', 'notification_failure_rate', 'notification_channels'], updated_at: '2025-09-24T10:30:00Z', updatedBy: 'Admin User' },
-    "平台": { widgetIds: ['platform_tags_defined', 'platform_auth_provider', 'platform_mail_status'], updated_at: '2025-09-24T10:30:00Z', updatedBy: 'Admin User' },
-    "profile": { widgetIds: ['profile_login_count_7d', 'profile_last_password_change', 'profile_mfa_status'], updated_at: '2025-09-24T10:30:00Z', updatedBy: 'Admin User' },
+const DEFAULT_LAYOUTS: Record<string, { widget_ids: string[]; updated_at: string; updated_by: string; }> = {
+    "SREWarRoom": { widget_ids: ['sre_pending_incidents', 'sre_in_progress', 'sre_resolved_today', 'sre_automation_rate'], updated_at: '2025-09-24T10:30:00Z', updated_by: 'Admin User' },
+    "InfrastructureInsights": { widget_ids: ['infra_total_resources', 'infra_running', 'infra_anomalies', 'infra_offline'], updated_at: '2025-09-24T10:30:00Z', updated_by: 'Admin User' },
+    "事件": { widget_ids: ['incident_pending_count', 'incident_in_progress', 'incident_resolved_today'], updated_at: '2025-09-24T10:30:00Z', updated_by: 'Admin User' },
+    "資源": { widget_ids: ['resource_total_count', 'resource_health_rate', 'resource_alerting'], updated_at: '2025-09-24T10:30:00Z', updated_by: 'Admin User' },
+    "ResourceOverview": { widget_ids: ['resource_total_count', 'resource_health_rate', 'resource_alerting', 'resource_group_count'], updated_at: '2025-09-24T10:30:00Z', updated_by: 'Admin User' },
+    "儀表板": { widget_ids: ['dashboard_total_count', 'dashboard_custom_count', 'dashboard_grafana_count'], updated_at: '2025-09-24T10:30:00Z', updated_by: 'Admin User' },
+    "智慧排查": { widget_ids: ['analysis_critical_anomalies', 'analysis_log_volume', 'analysis_trace_errors'], updated_at: '2025-09-24T10:30:00Z', updated_by: 'Admin User' },
+    "自動化": { widget_ids: ['automation_runs_today', 'automation_success_rate', 'automation_suppressed_alerts'], updated_at: '2025-09-24T10:30:00Z', updated_by: 'Admin User' },
+    "身份與存取管理": { widget_ids: ['iam_total_users', 'iam_active_users', 'iam_login_failures'], updated_at: '2025-09-24T10:30:00Z', updated_by: 'Admin User' },
+    "通知": { widget_ids: ['notification_sent_today', 'notification_failure_rate', 'notification_channels'], updated_at: '2025-09-24T10:30:00Z', updated_by: 'Admin User' },
+    "平台": { widget_ids: ['platform_tags_defined', 'platform_auth_provider', 'platform_mail_status'], updated_at: '2025-09-24T10:30:00Z', updated_by: 'Admin User' },
+    "profile": { widget_ids: ['profile_login_count_7d', 'profile_last_password_change', 'profile_mfa_status'], updated_at: '2025-09-24T10:30:00Z', updated_by: 'Admin User' },
 };
 const KPI_DATA: Record<string, any> = {
-    'incident_pending_count': { value: '5', description: '2 嚴重', icon: 'shield-alert', iconBgColor: 'bg-red-500' },
-    'incident_in_progress': { value: '3', description: '↓15% vs yesterday', icon: 'clock', iconBgColor: 'bg-yellow-500' },
-    'incident_resolved_today': { value: '12', description: '↑8% vs yesterday', icon: 'check-circle', iconBgColor: 'bg-green-500' },
-    'sre_pending_incidents': { value: '5', description: '2 嚴重', icon: 'shield-alert', iconBgColor: 'bg-red-500' },
-    'sre_in_progress': { value: '3', description: '↓15% vs yesterday', icon: 'clock', iconBgColor: 'bg-yellow-500' },
-    'sre_resolved_today': { value: '12', description: '↑8% vs yesterday', icon: 'check-circle', iconBgColor: 'bg-green-500' },
-    'sre_automation_rate': { value: '35.2%', description: '4 事件自動解決', icon: 'bot', iconBgColor: 'bg-sky-500' },
-    'infra_total_resources': { value: '120', description: '跨雲供應商', icon: 'database-zap', iconBgColor: 'bg-blue-500' },
-    'infra_running': { value: '115', description: '95.8% 健康', icon: 'heart-pulse', iconBgColor: 'bg-green-500' },
-    'infra_anomalies': { value: '5', description: '4.2% 需要關注', icon: 'siren', iconBgColor: 'bg-orange-500' },
-    'infra_offline': { value: '0', description: '0% 離線', icon: 'cloud-off', iconBgColor: 'bg-slate-500' },
+    'incident_pending_count': { value: '5', description: '2 嚴重', icon: 'shield-alert', icon_bg_color: 'bg-red-500' },
+    'incident_in_progress': { value: '3', description: '↓15% vs yesterday', icon: 'clock', icon_bg_color: 'bg-yellow-500' },
+    'incident_resolved_today': { value: '12', description: '↑8% vs yesterday', icon: 'check-circle', icon_bg_color: 'bg-green-500' },
+    'sre_pending_incidents': { value: '5', description: '2 嚴重', icon: 'shield-alert', icon_bg_color: 'bg-red-500' },
+    'sre_in_progress': { value: '3', description: '↓15% vs yesterday', icon: 'clock', icon_bg_color: 'bg-yellow-500' },
+    'sre_resolved_today': { value: '12', description: '↑8% vs yesterday', icon: 'check-circle', icon_bg_color: 'bg-green-500' },
+    'sre_automation_rate': { value: '35.2%', description: '4 事件自動解決', icon: 'bot', icon_bg_color: 'bg-sky-500' },
+    'infra_total_resources': { value: '120', description: '跨雲供應商', icon: 'database-zap', icon_bg_color: 'bg-blue-500' },
+    'infra_running': { value: '115', description: '95.8% 健康', icon: 'heart-pulse', icon_bg_color: 'bg-green-500' },
+    'infra_anomalies': { value: '5', description: '4.2% 需要關注', icon: 'siren', icon_bg_color: 'bg-orange-500' },
+    'infra_offline': { value: '0', description: '0% 離線', icon: 'cloud-off', icon_bg_color: 'bg-slate-500' },
 
     // NEW DATA
-    'resource_total_count': { value: '345', description: '↑2% vs last week', icon: 'database', iconBgColor: 'bg-blue-500' },
-    'resource_health_rate': { value: '98.5%', description: '340 健康', icon: 'heart-pulse', iconBgColor: 'bg-green-500' },
-    'resource_alerting': { value: '5', description: '3 critical, 2 warning', icon: 'siren', iconBgColor: 'bg-orange-500' },
-    'resource_group_count': { value: '15', description: '↑2 vs last month', icon: 'layout-grid', iconBgColor: 'bg-purple-500' },
+    'resource_total_count': { value: '345', description: '↑2% vs last week', icon: 'database', icon_bg_color: 'bg-blue-500' },
+    'resource_health_rate': { value: '98.5%', description: '340 健康', icon: 'heart-pulse', icon_bg_color: 'bg-green-500' },
+    'resource_alerting': { value: '5', description: '3 critical, 2 warning', icon: 'siren', icon_bg_color: 'bg-orange-500' },
+    'resource_group_count': { value: '15', description: '↑2 vs last month', icon: 'layout-grid', icon_bg_color: 'bg-purple-500' },
 
-    'dashboard_total_count': { value: '28', description: '↑3 vs last month', icon: 'layout-dashboard', iconBgColor: 'bg-indigo-500' },
-    'dashboard_custom_count': { value: '12', description: '使用者自訂的內建儀表板數量。', icon: 'layout-template', iconBgColor: 'bg-cyan-500' },
-    'dashboard_grafana_count': { value: '16', description: '從 Grafana 連結的儀表板數量。', icon: 'area-chart', iconBgColor: 'bg-green-500' },
+    'dashboard_total_count': { value: '28', description: '↑3 vs last month', icon: 'layout-dashboard', icon_bg_color: 'bg-indigo-500' },
+    'dashboard_custom_count': { value: '12', description: '使用者自訂的內建儀表板數量。', icon: 'layout-template', icon_bg_color: 'bg-cyan-500' },
+    'dashboard_grafana_count': { value: '16', description: '從 Grafana 連結的儀表板數量。', icon: 'area-chart', icon_bg_color: 'bg-green-500' },
 
-    'analysis_critical_anomalies': { value: '3', description: '↑1 vs yesterday', icon: 'zap', iconBgColor: 'bg-red-500' },
-    'analysis_log_volume': { value: '25.1 GB', description: '↓5% vs yesterday', icon: 'file-text', iconBgColor: 'bg-teal-500' },
-    'analysis_trace_errors': { value: '1.2%', description: '↑0.3% vs last hour', icon: 'git-fork', iconBgColor: 'bg-orange-500' },
+    'analysis_critical_anomalies': { value: '3', description: '↑1 vs yesterday', icon: 'zap', icon_bg_color: 'bg-red-500' },
+    'analysis_log_volume': { value: '25.1 GB', description: '↓5% vs yesterday', icon: 'file-text', icon_bg_color: 'bg-teal-500' },
+    'analysis_trace_errors': { value: '1.2%', description: '↑0.3% vs last hour', icon: 'git-fork', icon_bg_color: 'bg-orange-500' },
 
-    'automation_runs_today': { value: '1,283', description: '↑10% vs yesterday', icon: 'bot', iconBgColor: 'bg-sky-500' },
-    'automation_success_rate': { value: '99.8%', description: '2 failures', icon: 'check-circle', iconBgColor: 'bg-green-500' },
-    'automation_suppressed_alerts': { value: '45', description: 'Saved 2 hours of toil', icon: 'bell-off', iconBgColor: 'bg-purple-500' },
+    'automation_runs_today': { value: '1,283', description: '↑10% vs yesterday', icon: 'bot', icon_bg_color: 'bg-sky-500' },
+    'automation_success_rate': { value: '99.8%', description: '2 failures', icon: 'check-circle', icon_bg_color: 'bg-green-500' },
+    'automation_suppressed_alerts': { value: '45', description: 'Saved 2 hours of toil', icon: 'bell-off', icon_bg_color: 'bg-purple-500' },
 
-    'iam_total_users': { value: '124', description: '↑5 new users this month', icon: 'users', iconBgColor: 'bg-cyan-500' },
-    'iam_active_users': { value: '98', description: '79% active rate', icon: 'user-check', iconBgColor: 'bg-green-500' },
-    'iam_login_failures': { value: '8', description: 'From 3 unique IPs', icon: 'shield-off', iconBgColor: 'bg-red-500' },
+    'iam_total_users': { value: '124', description: '↑5 new users this month', icon: 'users', icon_bg_color: 'bg-cyan-500' },
+    'iam_active_users': { value: '98', description: '79% active rate', icon: 'user-check', icon_bg_color: 'bg-green-500' },
+    'iam_login_failures': { value: '8', description: 'From 3 unique IPs', icon: 'shield-off', icon_bg_color: 'bg-red-500' },
 
-    'notification_sent_today': { value: '342', description: '25 critical alerts', icon: 'send', iconBgColor: 'bg-blue-500' },
-    'notification_failure_rate': { value: '0.5%', description: '2 failed sends', icon: 'alert-triangle', iconBgColor: 'bg-orange-500' },
-    'notification_channels': { value: '8', description: 'Email, Slack, Webhook', icon: 'share-2', iconBgColor: 'bg-teal-500' },
+    'notification_sent_today': { value: '342', description: '25 critical alerts', icon: 'send', icon_bg_color: 'bg-blue-500' },
+    'notification_failure_rate': { value: '0.5%', description: '2 failed sends', icon: 'alert-triangle', icon_bg_color: 'bg-orange-500' },
+    'notification_channels': { value: '8', description: 'Email, Slack, Webhook', icon: 'share-2', icon_bg_color: 'bg-teal-500' },
 
-    'platform_tags_defined': { value: '42', description: '12 required tags', icon: 'tags', iconBgColor: 'bg-indigo-500' },
-    'platform_auth_provider': { value: 'Keycloak', description: 'OIDC Enabled', icon: 'key', iconBgColor: 'bg-yellow-500' },
-    'platform_mail_status': { value: 'Healthy', description: 'SMTP service is operational', icon: 'mail', iconBgColor: 'bg-green-500' },
+    'platform_tags_defined': { value: '42', description: '12 required tags', icon: 'tags', icon_bg_color: 'bg-indigo-500' },
+    'platform_auth_provider': { value: 'Keycloak', description: 'OIDC Enabled', icon: 'key', icon_bg_color: 'bg-yellow-500' },
+    'platform_mail_status': { value: 'Healthy', description: 'SMTP service is operational', icon: 'mail', icon_bg_color: 'bg-green-500' },
 
     // Personal Settings
-    'profile_login_count_7d': { value: '8', description: '來自 2 個不同 IP', icon: 'log-in', iconBgColor: 'bg-blue-500' },
-    'profile_last_password_change': { value: '3 天前', description: '建議每 90 天更新一次', icon: 'key', iconBgColor: 'bg-yellow-500' },
-    'profile_mfa_status': { value: '已啟用', description: '您的帳戶受到保護', icon: 'shield-check', iconBgColor: 'bg-green-500' },
+    'profile_login_count_7d': { value: '8', description: '來自 2 個不同 IP', icon: 'log-in', icon_bg_color: 'bg-blue-500' },
+    'profile_last_password_change': { value: '3 天前', description: '建議每 90 天更新一次', icon: 'key', icon_bg_color: 'bg-yellow-500' },
+    'profile_mfa_status': { value: '已啟用', description: '您的帳戶受到保護', icon: 'shield-check', icon_bg_color: 'bg-green-500' },
 };
 const MOCK_AI_BRIEFING = {
     "stability_summary": "系統整體穩定，但支付 API 錯誤率略高於正常水平，需持續關注。",
@@ -1739,7 +1739,7 @@ const MOCK_CONFIG_VERSIONS: ConfigVersion[] = [
         created_at: '2025-09-20T10:00:00Z'
     }
 ];
-const MOCK_USER_PREFERENCES: UserPreferences = { theme: 'dark', language: 'zh-TW', timezone: 'Asia/Taipei', defaultPage: 'sre-war-room' };
+const MOCK_USER_PREFERENCES: UserPreferences = { theme: 'dark', language: 'zh-TW', timezone: 'Asia/Taipei', default_page: 'sre-war-room' };
 
 // New AI Mock Data
 const MOCK_AI_RISK_PREDICTION = {
@@ -1765,9 +1765,9 @@ const MOCK_MULTI_INCIDENT_ANALYSIS: MultiIncidentAnalysis = {
 };
 
 const MOCK_ALERT_RULE_ANALYSIS: RuleAnalysisReport = {
-    reportType: 'alert',
+    report_type: 'alert',
     summary: '所選告警規則涵蓋關鍵 API 與基礎設施資源，其中 1 項規則被標記為高風險，建議調整閾值並加入額外指標交叉驗證。',
-    evaluatedRules: [
+    evaluated_rules: [
         { id: 'rule-001', name: 'CPU 使用率過高', status: '已啟用', severity: 'high' },
         { id: 'rule-002', name: 'API 延遲規則', status: '已啟用', severity: 'medium' },
     ],
@@ -1808,9 +1808,9 @@ const MOCK_ALERT_RULE_ANALYSIS: RuleAnalysisReport = {
 };
 
 const MOCK_SILENCE_RULE_ANALYSIS: RuleAnalysisReport = {
-    reportType: 'silence',
+    report_type: 'silence',
     summary: '靜音規則涵蓋週末維護窗口，但缺少針對緊急維護與例外條件的防護，建議補強覆蓋範圍並加入自動過期檢查。',
-    evaluatedRules: [
+    evaluated_rules: [
         { id: 'sil-001', name: '週末維護窗口', status: '已啟用', type: 'recurring' },
     ],
     metrics: [
@@ -1874,26 +1874,26 @@ const MOCK_LOG_ANALYSIS: LogAnalysis = {
 
 const MOCK_RESOURCE_ANALYSIS: ResourceAnalysis = {
     summary: '對選定的 5 個資源進行分析後，發現 2 個高風險資源，主要與潛在的容量瓶頸和過時的配置有關。此外，有 1 個資源存在成本優化機會。',
-    riskAnalysis: [
+    risk_analysis: [
         {
             resource_id: 'res-002',
-            resourceName: 'rds-prod-main',
-            riskLevel: 'High',
+            resource_name: 'rds-prod-main',
+            risk_level: 'High',
             reason: '記憶體使用率連續 3 天超過 90%，且慢查詢日誌數量增加。',
             recommendation: '建議立即升級資料庫實例類型，並分析慢查詢。'
         },
         {
             resource_id: 'res-007',
-            resourceName: 'api-service',
-            riskLevel: 'Medium',
+            resource_name: 'api-service',
+            risk_level: 'Medium',
             reason: '副本數 (3) 在流量高峰期可能不足，CPU Throttling 指標上升。',
             recommendation: '建議將 HPA 的最小副本數調整為 5。'
         }
     ],
-    optimizationSuggestions: [
+    optimization_suggestions: [
         {
             resource_id: 'res-004',
-            resourceName: 'web-prod-12',
+            resource_name: 'web-prod-12',
             suggestion: '此 EC2 實例的平均 CPU 使用率低於 10%。建議將實例類型從 `t3.large` 降級為 `t3.medium` 以節省成本。',
             type: 'Cost'
         }
@@ -1902,12 +1902,12 @@ const MOCK_RESOURCE_ANALYSIS: ResourceAnalysis = {
 
 const MOCK_EVENT_CORRELATION_DATA = {
     nodes: [
-        { id: 'INC-002', name: 'DB Connection Timeout', value: 10, symbolSize: 50, category: 0 },
-        { id: 'INC-001', name: 'API Latency Spike', value: 8, symbolSize: 40, category: 1 },
-        { id: 'Deployment-XYZ', name: 'Deployment', value: 5, symbolSize: 30, category: 2 },
-        { id: 'INC-003', name: '5xx Errors', value: 9, symbolSize: 45, category: 1 },
-        { id: 'res-002', name: 'rds-prod-main', value: 6, symbolSize: 35, category: 0 },
-        { id: 'res-001', name: 'api-gateway-prod-01', value: 6, symbolSize: 35, category: 1 },
+        { id: 'INC-002', name: 'DB Connection Timeout', value: 10, symbol_size: 50, category: 0 },
+        { id: 'INC-001', name: 'API Latency Spike', value: 8, symbol_size: 40, category: 1 },
+        { id: 'Deployment-XYZ', name: 'Deployment', value: 5, symbol_size: 30, category: 2 },
+        { id: 'INC-003', name: '5xx Errors', value: 9, symbol_size: 45, category: 1 },
+        { id: 'res-002', name: 'rds-prod-main', value: 6, symbol_size: 35, category: 0 },
+        { id: 'res-001', name: 'api-gateway-prod-01', value: 6, symbol_size: 35, category: 1 },
     ],
     links: [
         { source: 'res-002', target: 'INC-002' },
@@ -1928,7 +1928,7 @@ const MOCK_CAPACITY_SUGGESTIONS = [
         impact: '高' as const,
         effort: '中' as const,
         details: '`k8s-prod-cluster` 的 CPU 預計在 15 天內達到 95%。建議增加 2 個節點以避免效能下降。',
-        detectedAt: new Date(Date.now() - 60 * 60 * 1000).toISOString(),
+        detected_at: new Date(Date.now() - 60 * 60 * 1000).toISOString(),
         resource_id: 'res-1001',
     },
     {
@@ -1937,7 +1937,7 @@ const MOCK_CAPACITY_SUGGESTIONS = [
         impact: '中' as const,
         effort: '高' as const,
         details: '`rds-prod-main` 的記憶體使用率持續增長。建議從 `db.t3.large` 升級至 `db.t3.xlarge`。',
-        detectedAt: new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString(),
+        detected_at: new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString(),
         resource_id: 'res-1024',
     },
     {
@@ -1946,7 +1946,7 @@ const MOCK_CAPACITY_SUGGESTIONS = [
         impact: '低' as const,
         effort: '低' as const,
         details: '`s3-log-archive` 儲存桶已超過 5TB。建議設定生命週期規則以降低成本。',
-        detectedAt: new Date(Date.now() - 6 * 60 * 60 * 1000).toISOString(),
+        detected_at: new Date(Date.now() - 6 * 60 * 60 * 1000).toISOString(),
         resource_id: 'res-1077',
     },
 ];
@@ -1954,74 +1954,74 @@ const MOCK_CAPACITY_RESOURCE_ANALYSIS = [
     {
         id: 'cap-resource-001',
         resource_id: 'res-201',
-        resourceName: 'api-gateway-prod-01',
-        currentUtilization: 55,
-        forecastUtilization: 75,
+        resource_name: 'api-gateway-prod-01',
+        current_utilization: 55,
+        forecast_utilization: 75,
         recommendation: {
             label: '擴展',
             action: 'scale_up' as const,
             severity: 'warning' as const,
         },
-        costImpact: {
+        cost_impact: {
             label: '+$150/月',
-            monthlyDelta: 150,
+            monthly_delta: 150,
             currency: 'USD',
         },
-        lastEvaluatedAt: new Date(Date.now() - 30 * 60 * 1000).toISOString(),
+        last_evaluated_at: new Date(Date.now() - 30 * 60 * 1000).toISOString(),
     },
     {
         id: 'cap-resource-002',
         resource_id: 'res-305',
-        resourceName: 'rds-prod-main',
-        currentUtilization: 62,
-        forecastUtilization: 68,
+        resource_name: 'rds-prod-main',
+        current_utilization: 62,
+        forecast_utilization: 68,
         recommendation: {
             label: '觀察',
             action: 'monitor' as const,
             severity: 'info' as const,
         },
-        costImpact: {
+        cost_impact: {
             label: '-',
-            monthlyDelta: null,
+            monthly_delta: null,
             currency: null,
         },
-        lastEvaluatedAt: new Date(Date.now() - 45 * 60 * 1000).toISOString(),
+        last_evaluated_at: new Date(Date.now() - 45 * 60 * 1000).toISOString(),
     },
     {
         id: 'cap-resource-003',
         resource_id: 'res-415',
-        resourceName: 'k8s-prod-cluster-node-1',
-        currentUtilization: 85,
-        forecastUtilization: 98,
+        resource_name: 'k8s-prod-cluster-node-1',
+        current_utilization: 85,
+        forecast_utilization: 98,
         recommendation: {
             label: '緊急擴展',
             action: 'scale_up' as const,
             severity: 'critical' as const,
         },
-        costImpact: {
+        cost_impact: {
             label: '+$200/月',
-            monthlyDelta: 200,
+            monthly_delta: 200,
             currency: 'USD',
         },
-        lastEvaluatedAt: new Date(Date.now() - 20 * 60 * 1000).toISOString(),
+        last_evaluated_at: new Date(Date.now() - 20 * 60 * 1000).toISOString(),
     },
     {
         id: 'cap-resource-004',
         resource_id: 'res-522',
-        resourceName: 'elasticache-prod-03',
-        currentUtilization: 40,
-        forecastUtilization: 45,
+        resource_name: 'elasticache-prod-03',
+        current_utilization: 40,
+        forecast_utilization: 45,
         recommendation: {
             label: '觀察',
             action: 'monitor' as const,
             severity: 'info' as const,
         },
-        costImpact: {
+        cost_impact: {
             label: '-',
-            monthlyDelta: null,
+            monthly_delta: null,
             currency: null,
         },
-        lastEvaluatedAt: new Date(Date.now() - 90 * 60 * 1000).toISOString(),
+        last_evaluated_at: new Date(Date.now() - 90 * 60 * 1000).toISOString(),
     },
 ];
 const MOCK_CAPACITY_TIME_OPTIONS = [
@@ -2064,7 +2064,7 @@ const MOCK_ANALYSIS_OVERVIEW_DATA = {
 };
 
 const MOCK_PLATFORM_SETTINGS: PlatformSettings = {
-    helpUrl: 'https://docs.sre-platform.dev/help-center'
+    help_url: 'https://docs.sre-platform.dev/help-center'
 };
 
 const MOCK_PREFERENCE_OPTIONS: PreferenceOptions = {
@@ -2072,7 +2072,7 @@ const MOCK_PREFERENCE_OPTIONS: PreferenceOptions = {
         theme: 'dark',
         language: 'zh-TW',
         timezone: 'Asia/Taipei',
-        defaultPage: 'sre-war-room',
+        default_page: 'sre-war-room',
     },
     timezones: ['Asia/Taipei', 'UTC', 'America/New_York', 'Europe/London'],
     languages: [{ value: 'en', label: 'English' }, { value: 'zh-TW', label: '繁體中文' }],
@@ -2117,7 +2117,7 @@ const MOCK_TAB_CONFIGS: TabConfigMap = {
         { label: '通知管道', path: '/settings/notification-management/channels', icon: 'share-2' },
         { label: '發送歷史', path: '/settings/notification-management/history', icon: 'history' },
     ],
-    platformSettings: [
+    platform_settings: [
         { label: '標籤管理', path: '/settings/platform-settings', icon: 'tags' },
         { label: '郵件設定', path: '/settings/platform-settings/mail', icon: 'mail' },
         { label: '身份驗證', path: '/settings/platform-settings/auth', icon: 'key' },
@@ -2132,37 +2132,37 @@ const MOCK_TAB_CONFIGS: TabConfigMap = {
     ]
 };
 
-const INCIDENT_STATUS_STYLES: Record<string, { label: string; className: string }> = {
-    New: { label: '新事件', className: 'bg-gradient-to-r from-amber-500 to-orange-500 text-white border border-amber-400/30 shadow-sm' },
-    Acknowledged: { label: '已認領', className: 'bg-gradient-to-r from-sky-500 to-blue-500 text-white border border-sky-400/30 shadow-sm' },
-    Resolved: { label: '已解決', className: 'bg-gradient-to-r from-emerald-500 to-green-500 text-white border border-emerald-400/30 shadow-sm' },
-    Silenced: { label: '已靜音', className: 'bg-gradient-to-r from-slate-600 to-slate-500 text-slate-200 border border-slate-500/30 shadow-sm' },
+const INCIDENT_STATUS_STYLES: Record<string, { label: string; class_name: string }> = {
+    New: { label: '新事件', class_name: 'bg-gradient-to-r from-amber-500 to-orange-500 text-white border border-amber-400/30 shadow-sm' },
+    Acknowledged: { label: '已認領', class_name: 'bg-gradient-to-r from-sky-500 to-blue-500 text-white border border-sky-400/30 shadow-sm' },
+    Resolved: { label: '已解決', class_name: 'bg-gradient-to-r from-emerald-500 to-green-500 text-white border border-emerald-400/30 shadow-sm' },
+    Silenced: { label: '已靜音', class_name: 'bg-gradient-to-r from-slate-600 to-slate-500 text-slate-200 border border-slate-500/30 shadow-sm' },
 };
 
-const INCIDENT_SEVERITY_STYLES: Record<string, { label: string; className: string }> = {
-    Info: { label: '資訊', className: 'bg-sky-950/40 border border-sky-500/40 text-sky-300 backdrop-blur-sm shadow-sm' },
-    Warning: { label: '警告', className: 'bg-amber-950/40 border border-amber-500/40 text-amber-300 backdrop-blur-sm shadow-sm' },
-    Critical: { label: '嚴重', className: 'bg-red-950/40 border border-red-500/40 text-red-300 backdrop-blur-sm shadow-sm' },
+const INCIDENT_SEVERITY_STYLES: Record<string, { label: string; class_name: string }> = {
+    Info: { label: '資訊', class_name: 'bg-sky-950/40 border border-sky-500/40 text-sky-300 backdrop-blur-sm shadow-sm' },
+    Warning: { label: '警告', class_name: 'bg-amber-950/40 border border-amber-500/40 text-amber-300 backdrop-blur-sm shadow-sm' },
+    Critical: { label: '嚴重', class_name: 'bg-red-950/40 border border-red-500/40 text-red-300 backdrop-blur-sm shadow-sm' },
 };
 
-const INCIDENT_IMPACT_STYLES: Record<string, { label: string; className: string }> = {
-    High: { label: '高', className: 'bg-red-950/40 border border-red-500/40 text-red-300 backdrop-blur-sm shadow-sm' },
-    Medium: { label: '中', className: 'bg-amber-950/40 border border-amber-500/40 text-amber-300 backdrop-blur-sm shadow-sm' },
-    Low: { label: '低', className: 'bg-yellow-950/40 border border-yellow-500/40 text-yellow-300 backdrop-blur-sm shadow-sm' },
+const INCIDENT_IMPACT_STYLES: Record<string, { label: string; class_name: string }> = {
+    High: { label: '高', class_name: 'bg-red-950/40 border border-red-500/40 text-red-300 backdrop-blur-sm shadow-sm' },
+    Medium: { label: '中', class_name: 'bg-amber-950/40 border border-amber-500/40 text-amber-300 backdrop-blur-sm shadow-sm' },
+    Low: { label: '低', class_name: 'bg-yellow-950/40 border border-yellow-500/40 text-yellow-300 backdrop-blur-sm shadow-sm' },
 };
 
-const buildIncidentStyleOptions = <T extends string>(values: T[], styleMap: Record<string, { label: string; className: string }>): StyleDescriptor<T>[] =>
+const buildIncidentStyleOptions = <T extends string>(values: T[], style_map: Record<string, { label: string; class_name: string }>): StyleDescriptor<T>[] =>
     values.map((value: T) => ({
         value,
         label: styleMap[value]?.label ?? value,
-        className: styleMap[value]?.className ?? 'bg-slate-800/60 border border-slate-600 text-slate-200',
+        class_name: styleMap[value]?.className ?? 'bg-slate-800/60 border border-slate-600 text-slate-200',
     }));
 
 const MOCK_INCIDENT_OPTIONS: IncidentOptions = {
     statuses: buildIncidentStyleOptions(getEnumValuesForTag('status') as Incident['status'][], INCIDENT_STATUS_STYLES),
     severities: buildIncidentStyleOptions(getEnumValuesForTag('severity') as Incident['severity'][], INCIDENT_SEVERITY_STYLES),
     impacts: buildIncidentStyleOptions(getEnumValuesForTag('impact') as Incident['impact'][], INCIDENT_IMPACT_STYLES),
-    quickSilenceDurations: [
+    quick_silence_durations: [
         { label: '1 小時', value: 1 },
         { label: '4 小時', value: 4 },
         { label: '8 小時', value: 8 },
@@ -2172,40 +2172,40 @@ const MOCK_INCIDENT_OPTIONS: IncidentOptions = {
     ],
 };
 
-const ALERT_RULE_SEVERITY_DESCRIPTORS: Record<AlertRule['severity'], { label: string; className: string }> = {
-    critical: { label: '嚴重', className: 'bg-red-950/40 border border-red-500/40 text-red-300 backdrop-blur-sm shadow-sm' },
-    warning: { label: '警告', className: 'bg-amber-950/40 border border-amber-500/40 text-amber-300 backdrop-blur-sm shadow-sm' },
-    info: { label: '資訊', className: 'bg-sky-950/40 border border-sky-500/40 text-sky-300 backdrop-blur-sm shadow-sm' },
+const ALERT_RULE_SEVERITY_DESCRIPTORS: Record<AlertRule['severity'], { label: string; class_name: string }> = {
+    critical: { label: '嚴重', class_name: 'bg-red-950/40 border border-red-500/40 text-red-300 backdrop-blur-sm shadow-sm' },
+    warning: { label: '警告', class_name: 'bg-amber-950/40 border border-amber-500/40 text-amber-300 backdrop-blur-sm shadow-sm' },
+    info: { label: '資訊', class_name: 'bg-sky-950/40 border border-sky-500/40 text-sky-300 backdrop-blur-sm shadow-sm' },
 };
 
 const MOCK_ALERT_RULE_OPTIONS: AlertRuleOptions = {
     severities: (['critical', 'warning', 'info'] as AlertRule['severity'][]).map(value => ({
         value,
         label: ALERT_RULE_SEVERITY_DESCRIPTORS[value].label,
-        className: ALERT_RULE_SEVERITY_DESCRIPTORS[value].className,
+        class_name: ALERT_RULE_SEVERITY_DESCRIPTORS[value].className,
     })),
     statuses: [
         { value: true, label: 'Enabled' },
         { value: false, label: 'Disabled' }
     ],
     operators: ['>', '<', '>=', '<='],
-    scopeModes: [
+    scope_modes: [
         { value: 'all', label: 'All Resources (by type)' },
         { value: 'group', label: 'By Resource Group' },
         { value: 'specific', label: 'Specific Resources' },
     ],
     variables: ['{{severity}}', '{{resource.name}}', '{{metric}}', '{{value}}', '{{threshold}}', '{{duration}}'],
-    stepTitles: ["選擇監控目標", "設定基本資訊", "定義觸發條件", "事件定義與通知", "設定自動化響應"],
+    step_titles: ["選擇監控目標", "設定基本資訊", "定義觸發條件", "事件定義與通知", "設定自動化響應"],
 };
 
 const MOCK_RESOURCE_OPTIONS: ResourceOptions = {
     statuses: [
-        { value: 'healthy', label: 'Healthy', className: 'bg-emerald-950/40 border border-emerald-500/40 text-emerald-300 backdrop-blur-sm shadow-sm' },
-        { value: 'warning', label: 'Warning', className: 'bg-amber-950/40 border border-amber-500/40 text-amber-300 backdrop-blur-sm shadow-sm' },
-        { value: 'critical', label: 'Critical', className: 'bg-red-950/40 border border-red-500/40 text-red-300 backdrop-blur-sm shadow-sm' },
-        { value: 'offline', label: 'Offline', className: 'bg-slate-950/40 border border-slate-500/40 text-slate-300 backdrop-blur-sm shadow-sm' },
+        { value: 'healthy', label: 'Healthy', class_name: 'bg-emerald-950/40 border border-emerald-500/40 text-emerald-300 backdrop-blur-sm shadow-sm' },
+        { value: 'warning', label: 'Warning', class_name: 'bg-amber-950/40 border border-amber-500/40 text-amber-300 backdrop-blur-sm shadow-sm' },
+        { value: 'critical', label: 'Critical', class_name: 'bg-red-950/40 border border-red-500/40 text-red-300 backdrop-blur-sm shadow-sm' },
+        { value: 'offline', label: 'Offline', class_name: 'bg-slate-950/40 border border-slate-500/40 text-slate-300 backdrop-blur-sm shadow-sm' },
     ],
-    statusColors: [
+    status_colors: [
         { value: 'healthy', label: 'Healthy', color: '#10b981' },
         { value: 'warning', label: 'Warning', color: '#f97316' },
         { value: 'critical', label: 'Critical', color: '#dc2626' },
@@ -2218,13 +2218,13 @@ const MOCK_RESOURCE_OPTIONS: ResourceOptions = {
 };
 
 const MOCK_AUTOMATION_SCRIPT_OPTIONS: AutomationScriptOptions = {
-    playbookTypes: [
+    playbook_types: [
         { value: 'shell', label: 'Shell' },
         { value: 'python', label: 'Python' },
         { value: 'ansible', label: 'Ansible' },
         { value: 'terraform', label: 'Terraform' }
     ],
-    parameterTypes: [
+    parameter_types: [
         { value: 'string', label: 'String' },
         { value: 'number', label: 'Number' },
         { value: 'enum', label: 'Enum' },
@@ -2234,12 +2234,12 @@ const MOCK_AUTOMATION_SCRIPT_OPTIONS: AutomationScriptOptions = {
 
 const MOCK_AUTOMATION_EXECUTION_OPTIONS: AutomationExecutionOptions = {
     statuses: [
-        { value: 'success', label: '成功', className: 'bg-green-500/20 text-green-400' },
-        { value: 'failed', label: '失敗', className: 'bg-red-500/20 text-red-400' },
-        { value: 'running', label: '執行中', className: 'bg-sky-500/20 text-sky-400' },
-        { value: 'pending', label: '等待中', className: 'bg-yellow-500/20 text-yellow-400' },
+        { value: 'success', label: '成功', class_name: 'bg-green-500/20 text-green-400' },
+        { value: 'failed', label: '失敗', class_name: 'bg-red-500/20 text-red-400' },
+        { value: 'running', label: '執行中', class_name: 'bg-sky-500/20 text-sky-400' },
+        { value: 'pending', label: '等待中', class_name: 'bg-yellow-500/20 text-yellow-400' },
     ],
-    triggerSources: [
+    trigger_sources: [
         { value: 'event', label: '事件觸發' },
         { value: 'manual', label: '手動執行' },
         { value: 'schedule', label: '排程觸發' },
@@ -2248,27 +2248,27 @@ const MOCK_AUTOMATION_EXECUTION_OPTIONS: AutomationExecutionOptions = {
 };
 
 const MOCK_NOTIFICATION_CHANNEL_OPTIONS: NotificationChannelOptions = {
-    channelTypes: [
+    channel_types: [
         { value: 'Email', label: 'Email' },
         { value: 'Webhook (通用)', label: 'Webhook (通用)' },
         { value: 'Slack', label: 'Slack' },
         { value: 'LINE Notify', label: 'LINE Notify' },
         { value: 'SMS', label: 'SMS' }
     ],
-    httpMethods: ['POST', 'PUT', 'GET']
+    http_methods: ['POST', 'PUT', 'GET']
 };
 
 const MOCK_AUTOMATION_TRIGGER_SEVERITY_OPTIONS = MOCK_ALERT_RULE_OPTIONS.severities.map(({ value, label }) => ({ value, label }));
 
 const MOCK_AUTOMATION_TRIGGER_OPTIONS: AutomationTriggerOptions = {
-    triggerTypes: [
+    trigger_types: [
         { value: 'Schedule', label: '排程' },
         { value: 'Webhook', label: 'Webhook' },
         { value: 'Event', label: '事件' }
     ],
-    conditionKeys: ['severity', 'resource.type', 'tag.env'],
-    severityOptions: MOCK_AUTOMATION_TRIGGER_SEVERITY_OPTIONS,
-    defaultConfigs: {
+    condition_keys: ['severity', 'resource.type', 'tag.env'],
+    severity_options: MOCK_AUTOMATION_TRIGGER_SEVERITY_OPTIONS,
+    default_configs: {
         'Schedule': { cron: '0 * * * *' },
         'Webhook': { webhook_url: 'https://sre.platform/api/v1/webhooks/hook-generated-id' },
         'Event': { event_conditions: `severity = ${MOCK_AUTOMATION_TRIGGER_SEVERITY_OPTIONS[0]?.value ?? 'critical'}` }
@@ -2277,9 +2277,9 @@ const MOCK_AUTOMATION_TRIGGER_OPTIONS: AutomationTriggerOptions = {
 
 const MOCK_PERSONNEL_OPTIONS: PersonnelOptions = {
     statuses: [
-        { value: 'active', label: 'Active', className: 'bg-green-500/20 text-green-400' },
-        { value: 'invited', label: 'Invited', className: 'bg-yellow-500/20 text-yellow-400' },
-        { value: 'inactive', label: 'Inactive', className: 'bg-slate-500/20 text-slate-400' },
+        { value: 'active', label: 'Active', class_name: 'bg-green-500/20 text-green-400' },
+        { value: 'invited', label: 'Invited', class_name: 'bg-yellow-500/20 text-yellow-400' },
+        { value: 'inactive', label: 'Inactive', class_name: 'bg-slate-500/20 text-slate-400' },
     ],
 };
 
@@ -2289,29 +2289,29 @@ const MOCK_DASHBOARD_OPTIONS: DashboardOptions = {
 };
 
 const MOCK_AUDIT_LOG_OPTIONS: AuditLogOptions = {
-    actionTypes: ['LOGIN_SUCCESS', 'UPDATE_ALERT_RULE', 'CREATE_USER', 'DELETE_RESOURCE'],
+    action_types: ['LOGIN_SUCCESS', 'UPDATE_ALERT_RULE', 'CREATE_USER', 'DELETE_RESOURCE'],
 };
 
 const MOCK_LOG_OPTIONS: LogOptions = {
-    timeRangeOptions: MOCK_LOG_TIME_OPTIONS,
+    time_range_options: MOCK_LOG_TIME_OPTIONS,
 };
 
 const MOCK_INFRA_INSIGHTS_OPTIONS: InfraInsightsOptions = {
-    timeOptions: MOCK_GRAFANA_OPTIONS.timeOptions,
-    riskLevels: [
+    time_options: MOCK_GRAFANA_OPTIONS.timeOptions,
+    risk_levels: [
         { value: 'high', label: 'High', color: '#dc2626' },
         { value: 'medium', label: 'Medium', color: '#f97316' },
         { value: 'low', label: 'Low', color: '#10b981' },
     ],
-    refreshOptions: MOCK_GRAFANA_OPTIONS.refreshOptions,
-    tvModeOptions: MOCK_GRAFANA_OPTIONS.tvModeOptions,
-    themeOptions: MOCK_GRAFANA_OPTIONS.themeOptions,
+    refresh_options: MOCK_GRAFANA_OPTIONS.refreshOptions,
+    tv_mode_options: MOCK_GRAFANA_OPTIONS.tvModeOptions,
+    theme_options: MOCK_GRAFANA_OPTIONS.themeOptions,
 };
 
 const MOCK_TAG_MANAGEMENT_OPTIONS: TagManagementOptions = {
     scopes: TAG_SCOPE_OPTIONS,
-    writableRoles: ['platform_admin', 'sre_lead', 'compliance_officer'],
-    governanceNotes: '標籤鍵須符合治理規範：鍵名使用小寫與底線、枚舉值需在登錄處定義、不得於頁面臨時建立新鍵。',
+    writable_roles: ['platform_admin', 'sre_lead', 'compliance_officer'],
+    governance_notes: '標籤鍵須符合治理規範：鍵名使用小寫與底線、枚舉值需在登錄處定義、不得於頁面臨時建立新鍵。',
 };
 
 const MOCK_TOPOLOGY_OPTIONS: TopologyOptions = {
@@ -2326,7 +2326,7 @@ const MOCK_NOTIFICATION_HISTORY_OPTIONS: NotificationHistoryOptions = {
         { value: 'success', label: 'Success' },
         { value: 'failed', label: 'Failed' },
     ],
-    channelTypes: [
+    channel_types: [
         { value: 'Email', label: 'Email' },
         { value: 'Webhook (通用)', label: 'Webhook (通用)' },
         { value: 'Slack', label: 'Slack' },
@@ -2337,24 +2337,24 @@ const MOCK_NOTIFICATION_HISTORY_OPTIONS: NotificationHistoryOptions = {
 
 const MOCK_DATASOURCE_OPTIONS: DatasourceOptions = {
     types: ['VictoriaMetrics', 'Grafana', 'Elasticsearch', 'Prometheus', '自訂'],
-    authMethods: ['Token', 'Basic Auth', 'Keycloak 整合', '無'],
+    auth_methods: ['Token', 'Basic Auth', 'Keycloak 整合', '無'],
 };
 
 const MOCK_AUTO_DISCOVERY_OPTIONS: AutoDiscoveryOptions = {
-    jobKinds: ['K8s', 'SNMP', 'Cloud Provider', 'Static Range', 'Custom Script'],
-    exporterTemplates: [
+    job_kinds: ['K8s', 'SNMP', 'Cloud Provider', 'Static Range', 'Custom Script'],
+    exporter_templates: [
         { id: 'none', name: '不部署 Exporter', description: '僅建立資源資料，不自動綁定監控代理。' },
-        { id: 'node_exporter', name: 'Node Exporter', description: '適用於 Linux/Windows 主機的系統監控。', supportsOverrides: true },
-        { id: 'snmp_exporter', name: 'SNMP Exporter', description: '適用於網路設備與 OT 設備，支援 MIB Profile。', supportsMibProfile: true },
-        { id: 'modbus_exporter', name: 'Modbus Exporter', description: '用於 PLC 或工業設備，支援 YAML 覆寫。', supportsOverrides: true },
-        { id: 'ipmi_exporter', name: 'IPMI Exporter', description: '收集裸機 BMC 感測資料。', supportsOverrides: true },
+        { id: 'node_exporter', name: 'Node Exporter', description: '適用於 Linux/Windows 主機的系統監控。', supports_overrides: true },
+        { id: 'snmp_exporter', name: 'SNMP Exporter', description: '適用於網路設備與 OT 設備，支援 MIB Profile。', supports_mib_profile: true },
+        { id: 'modbus_exporter', name: 'Modbus Exporter', description: '用於 PLC 或工業設備，支援 YAML 覆寫。', supports_overrides: true },
+        { id: 'ipmi_exporter', name: 'IPMI Exporter', description: '收集裸機 BMC 感測資料。', supports_overrides: true },
     ],
-    mibProfiles: [
-        { id: 'snmp-default', name: '通用 SNMP Profile', description: '涵蓋 CPU/記憶體/網路等基礎 OID。', templateId: 'snmp_exporter' },
-        { id: 'snmp-cisco', name: 'Cisco 網路設備', description: '針對 Cisco 路由/交換器的延伸指標。', templateId: 'snmp_exporter' },
-        { id: 'modbus-energy', name: '能源表計', description: '量測溫度、電流、電壓等欄位。', templateId: 'modbus_exporter' },
+    mib_profiles: [
+        { id: 'snmp-default', name: '通用 SNMP Profile', description: '涵蓋 CPU/記憶體/網路等基礎 OID。', template_id: 'snmp_exporter' },
+        { id: 'snmp-cisco', name: 'Cisco 網路設備', description: '針對 Cisco 路由/交換器的延伸指標。', template_id: 'snmp_exporter' },
+        { id: 'modbus-energy', name: '能源表計', description: '量測溫度、電流、電壓等欄位。', template_id: 'modbus_exporter' },
     ],
-    edgeGateways: [
+    edge_gateways: [
         { id: 'edge-gw-1', name: 'IDC Edge Gateway', location: '台北 IDC', description: '連線至資料中心網段，提供 SNMP/Modbus 掃描。' },
         { id: 'edge-gw-2', name: 'Factory OT Gateway', location: '台中廠房', description: '工廠產線專用，支援隔離網段的 OT 探測。' },
     ],
@@ -2362,25 +2362,25 @@ const MOCK_AUTO_DISCOVERY_OPTIONS: AutoDiscoveryOptions = {
 
 const MOCK_ALL_OPTIONS: AllOptions = {
     incidents: MOCK_INCIDENT_OPTIONS,
-    alertRules: MOCK_ALERT_RULE_OPTIONS,
-    silenceRules: MOCK_SILENCE_RULE_OPTIONS,
+    alert_rules: MOCK_ALERT_RULE_OPTIONS,
+    silence_rules: MOCK_SILENCE_RULE_OPTIONS,
     resources: MOCK_RESOURCE_OPTIONS,
-    automationScripts: MOCK_AUTOMATION_SCRIPT_OPTIONS,
-    notificationChannels: MOCK_NOTIFICATION_CHANNEL_OPTIONS,
-    automationTriggers: MOCK_AUTOMATION_TRIGGER_OPTIONS,
+    automation_scripts: MOCK_AUTOMATION_SCRIPT_OPTIONS,
+    notification_channels: MOCK_NOTIFICATION_CHANNEL_OPTIONS,
+    automation_triggers: MOCK_AUTOMATION_TRIGGER_OPTIONS,
     personnel: MOCK_PERSONNEL_OPTIONS,
     dashboards: MOCK_DASHBOARD_OPTIONS,
-    notificationStrategies: MOCK_NOTIFICATION_STRATEGY_OPTIONS,
+    notification_strategies: MOCK_NOTIFICATION_STRATEGY_OPTIONS,
     grafana: MOCK_GRAFANA_OPTIONS,
-    auditLogs: MOCK_AUDIT_LOG_OPTIONS,
+    audit_logs: MOCK_AUDIT_LOG_OPTIONS,
     logs: MOCK_LOG_OPTIONS,
-    infraInsights: MOCK_INFRA_INSIGHTS_OPTIONS,
-    tagManagement: MOCK_TAG_MANAGEMENT_OPTIONS,
+    infra_insights: MOCK_INFRA_INSIGHTS_OPTIONS,
+    tag_management: MOCK_TAG_MANAGEMENT_OPTIONS,
     topology: MOCK_TOPOLOGY_OPTIONS,
-    automationExecutions: MOCK_AUTOMATION_EXECUTION_OPTIONS,
-    notificationHistory: MOCK_NOTIFICATION_HISTORY_OPTIONS,
+    automation_executions: MOCK_AUTOMATION_EXECUTION_OPTIONS,
+    notification_history: MOCK_NOTIFICATION_HISTORY_OPTIONS,
     datasources: MOCK_DATASOURCE_OPTIONS,
-    autoDiscovery: MOCK_AUTO_DISCOVERY_OPTIONS,
+    auto_discovery: MOCK_AUTO_DISCOVERY_OPTIONS,
 };
 
 const MOCK_DATASOURCES: Datasource[] = [
@@ -2391,7 +2391,7 @@ const MOCK_DATASOURCES: Datasource[] = [
         status: 'ok',
         created_at: '2025-09-01T12:30:00Z',
         url: 'http://prometheus-a.internal:9090',
-        authMethod: 'None',
+        auth_method: 'None',
         tags: [{ id: 'tag-1', key: 'env', value: 'production' }]
     },
     {
@@ -2401,7 +2401,7 @@ const MOCK_DATASOURCES: Datasource[] = [
         status: 'error',
         created_at: '2025-09-10T09:22:00Z',
         url: 'http://vm-cluster-1.internal:8428',
-        authMethod: 'Token',
+        auth_method: 'Token',
         tags: [{ id: 'tag-2', key: 'env', value: 'production' }, { id: 'tag-3', key: 'cluster', value: '1' }]
     },
     {
@@ -2411,7 +2411,7 @@ const MOCK_DATASOURCES: Datasource[] = [
         status: 'pending',
         created_at: '2025-09-11T15:00:00Z',
         url: 'http://grafana.internal',
-        authMethod: 'Keycloak Integration',
+        auth_method: 'Keycloak Integration',
         tags: []
     }
 ];
@@ -2424,9 +2424,9 @@ const MOCK_DISCOVERY_JOBS: DiscoveryJob[] = [
         schedule: '0 9 * * *', // 每天 09:00
         last_run_at: '2025-09-23T09:00:15Z',
         status: 'success',
-        targetConfig: { kubeconfig: '...' },
-        exporterBinding: { templateId: 'node_exporter' },
-        edgeGateway: { enabled: false },
+        target_config: { kubeconfig: '...' },
+        exporter_binding: { template_id: 'node_exporter' },
+        edge_gateway: { enabled: false },
         tags: [{ id: 'tag-4', key: 'cluster', value: 'A' }],
         created_at: '2025-09-01T09:00:00Z',
         updated_at: '2025-09-23T09:00:15Z',
@@ -2438,9 +2438,9 @@ const MOCK_DISCOVERY_JOBS: DiscoveryJob[] = [
         schedule: '30 * * * *', // 每小時 30 分
         last_run_at: '2025-09-23T10:30:05Z',
         status: 'partial_failure',
-        targetConfig: { community: 'public', ipRange: '10.1.1.1/24' },
-        exporterBinding: { templateId: 'snmp_exporter', mibProfileId: 'snmp-default' },
-        edgeGateway: { enabled: true, gatewayId: 'edge-gw-1' },
+        target_config: { community: 'public', ip_range: '10.1.1.1/24' },
+        exporter_binding: { template_id: 'snmp_exporter', mib_profile_id: 'snmp-default' },
+        edge_gateway: { enabled: true, gateway_id: 'edge-gw-1' },
         tags: [{ id: 'tag-5', key: 'datacenter', value: 'IDC-1' }],
         created_at: '2025-09-02T10:00:00Z',
         updated_at: '2025-09-23T10:30:05Z',
@@ -2452,9 +2452,9 @@ const MOCK_DISCOVERY_JOBS: DiscoveryJob[] = [
         schedule: '0 0 * * *', // 每天
         last_run_at: '2025-09-23T00:00:10Z',
         status: 'running',
-        targetConfig: { apiKey: '***masked***' },
-        exporterBinding: { templateId: 'node_exporter' },
-        edgeGateway: { enabled: false },
+        target_config: { api_key: '***masked***' },
+        exporter_binding: { template_id: 'node_exporter' },
+        edge_gateway: { enabled: false },
         tags: [],
         created_at: '2025-09-03T11:00:00Z',
         updated_at: '2025-09-23T00:00:10Z',
@@ -2472,111 +2472,111 @@ const MOCK_DISCOVERED_RESOURCES: DiscoveredResource[] = [
 function createInitialDB() {
     // Deep clone to make it mutable
     return {
-        metricMetadata: JSON.parse(JSON.stringify(MOCK_METRIC_METADATA)),
-        resourceTypes: JSON.parse(JSON.stringify(MOCK_RESOURCE_TYPES)),
-        exporterTypes: JSON.parse(JSON.stringify(MOCK_EXPORTER_TYPES)),
-        systemConfig: JSON.parse(JSON.stringify(MOCK_SYSTEM_CONFIG)),
+        metric_metadata: JSON.parse(JSON.stringify(MOCK_METRIC_METADATA)),
+        resource_types: JSON.parse(JSON.stringify(MOCK_RESOURCE_TYPES)),
+        exporter_types: JSON.parse(JSON.stringify(MOCK_EXPORTER_TYPES)),
+        system_config: JSON.parse(JSON.stringify(MOCK_SYSTEM_CONFIG)),
         commands: JSON.parse(JSON.stringify(MOCK_COMMANDS)),
-        pageMetadata: JSON.parse(JSON.stringify(MOCK_PAGE_METADATA)),
-        iconMap: JSON.parse(JSON.stringify(MOCK_ICON_MAP)),
-        chartColors: JSON.parse(JSON.stringify(MOCK_CHART_COLORS)),
-        navItems: JSON.parse(JSON.stringify(MOCK_NAV_ITEMS)),
+        page_metadata: JSON.parse(JSON.stringify(MOCK_PAGE_METADATA)),
+        icon_map: JSON.parse(JSON.stringify(MOCK_ICON_MAP)),
+        chart_colors: JSON.parse(JSON.stringify(MOCK_CHART_COLORS)),
+        nav_items: JSON.parse(JSON.stringify(MOCK_NAV_ITEMS)),
         dashboards: JSON.parse(JSON.stringify(MOCK_DASHBOARDS)),
-        availableGrafanaDashboards: JSON.parse(JSON.stringify(MOCK_AVAILABLE_GRAFANA_DASHBOARDS)),
-        dashboardTemplates: JSON.parse(JSON.stringify(MOCK_DASHBOARD_TEMPLATES)),
+        available_grafana_dashboards: JSON.parse(JSON.stringify(MOCK_AVAILABLE_GRAFANA_DASHBOARDS)),
+        dashboard_templates: JSON.parse(JSON.stringify(MOCK_DASHBOARD_TEMPLATES)),
         incidents: JSON.parse(JSON.stringify(MOCK_INCIDENTS)),
-        quickSilenceDurations: JSON.parse(JSON.stringify(MOCK_QUICK_SILENCE_DURATIONS)),
-        alertRuleDefault: JSON.parse(JSON.stringify(MOCK_ALERT_RULE_DEFAULT)),
-        alertRules: JSON.parse(JSON.stringify(MOCK_ALERT_RULES)),
-        alertRuleTemplates: JSON.parse(JSON.stringify(MOCK_ALERT_RULE_TEMPLATES)),
-        silenceRules: JSON.parse(JSON.stringify(MOCK_SILENCE_RULES)),
-        silenceRuleTemplates: JSON.parse(JSON.stringify(MOCK_SILENCE_RULE_TEMPLATES)),
-        silenceRuleOptions: JSON.parse(JSON.stringify(MOCK_SILENCE_RULE_OPTIONS)),
+        quick_silence_durations: JSON.parse(JSON.stringify(MOCK_QUICK_SILENCE_DURATIONS)),
+        alert_rule_default: JSON.parse(JSON.stringify(MOCK_ALERT_RULE_DEFAULT)),
+        alert_rules: JSON.parse(JSON.stringify(MOCK_ALERT_RULES)),
+        alert_rule_templates: JSON.parse(JSON.stringify(MOCK_ALERT_RULE_TEMPLATES)),
+        silence_rules: JSON.parse(JSON.stringify(MOCK_SILENCE_RULES)),
+        silence_rule_templates: JSON.parse(JSON.stringify(MOCK_SILENCE_RULE_TEMPLATES)),
+        silence_rule_options: JSON.parse(JSON.stringify(MOCK_SILENCE_RULE_OPTIONS)),
         resources: JSON.parse(JSON.stringify(MOCK_RESOURCES)),
-        resourceGroups: JSON.parse(JSON.stringify(MOCK_RESOURCE_GROUPS)),
-        resourceLinks: JSON.parse(JSON.stringify(MOCK_RESOURCE_LINKS)),
-        configVersions: JSON.parse(JSON.stringify(MOCK_CONFIG_VERSIONS)),
-        resourceOverviewData: JSON.parse(JSON.stringify(MOCK_RESOURCE_OVERVIEW_DATA)),
+        resource_groups: JSON.parse(JSON.stringify(MOCK_RESOURCE_GROUPS)),
+        resource_links: JSON.parse(JSON.stringify(MOCK_RESOURCE_LINKS)),
+        config_versions: JSON.parse(JSON.stringify(MOCK_CONFIG_VERSIONS)),
+        resource_overview_data: JSON.parse(JSON.stringify(MOCK_RESOURCE_OVERVIEW_DATA)),
         playbooks: JSON.parse(JSON.stringify(MOCK_PLAYBOOKS)),
-        automationExecutions: JSON.parse(JSON.stringify(MOCK_AUTOMATION_EXECUTIONS)),
-        automationTriggers: JSON.parse(JSON.stringify(MOCK_AUTOMATION_TRIGGERS)),
+        automation_executions: JSON.parse(JSON.stringify(MOCK_AUTOMATION_EXECUTIONS)),
+        automation_triggers: JSON.parse(JSON.stringify(MOCK_AUTOMATION_TRIGGERS)),
         users: JSON.parse(JSON.stringify(MOCK_USERS)),
-        userStatuses: JSON.parse(JSON.stringify(MOCK_USER_STATUSES)),
+        user_statuses: JSON.parse(JSON.stringify(MOCK_USER_STATUSES)),
         teams: JSON.parse(JSON.stringify(MOCK_TEAMS)),
         roles: JSON.parse(JSON.stringify(MOCK_ROLES)),
-        availablePermissions: JSON.parse(JSON.stringify(AVAILABLE_PERMISSIONS)),
-        auditLogs: JSON.parse(JSON.stringify(MOCK_AUDIT_LOGS)),
-        tagDefinitions: JSON.parse(JSON.stringify(MOCK_TAG_DEFINITIONS)),
+        available_permissions: JSON.parse(JSON.stringify(AVAILABLE_PERMISSIONS)),
+        audit_logs: JSON.parse(JSON.stringify(MOCK_AUDIT_LOGS)),
+        tag_definitions: JSON.parse(JSON.stringify(MOCK_TAG_DEFINITIONS)),
         notifications: JSON.parse(JSON.stringify(MOCK_NOTIFICATIONS)),
-        notificationStrategies: JSON.parse(JSON.stringify(MOCK_NOTIFICATION_STRATEGIES)),
-        notificationStrategyOptions: JSON.parse(JSON.stringify(MOCK_NOTIFICATION_STRATEGY_OPTIONS)),
-        notificationChannels: JSON.parse(JSON.stringify(MOCK_NOTIFICATION_CHANNELS)),
-        notificationChannelIcons: JSON.parse(JSON.stringify(MOCK_NOTIFICATION_CHANNEL_ICONS)),
-        notificationOptions: JSON.parse(JSON.stringify(MOCK_NOTIFICATION_OPTIONS)),
-        notificationHistory: JSON.parse(JSON.stringify(MOCK_NOTIFICATION_HISTORY)),
-        loginHistory: JSON.parse(JSON.stringify(MOCK_LOGIN_HISTORY)),
+        notification_strategies: JSON.parse(JSON.stringify(MOCK_NOTIFICATION_STRATEGIES)),
+        notification_strategy_options: JSON.parse(JSON.stringify(MOCK_NOTIFICATION_STRATEGY_OPTIONS)),
+        notification_channels: JSON.parse(JSON.stringify(MOCK_NOTIFICATION_CHANNELS)),
+        notification_channel_icons: JSON.parse(JSON.stringify(MOCK_NOTIFICATION_CHANNEL_ICONS)),
+        notification_options: JSON.parse(JSON.stringify(MOCK_NOTIFICATION_OPTIONS)),
+        notification_history: JSON.parse(JSON.stringify(MOCK_NOTIFICATION_HISTORY)),
+        login_history: JSON.parse(JSON.stringify(MOCK_LOGIN_HISTORY)),
         logs: JSON.parse(JSON.stringify(MOCK_LOGS)),
-        logTimeOptions: JSON.parse(JSON.stringify(MOCK_LOG_TIME_OPTIONS)),
-        mailSettings: JSON.parse(JSON.stringify(MOCK_MAIL_SETTINGS)),
-        grafanaSettings: JSON.parse(JSON.stringify(MOCK_GRAFANA_SETTINGS)),
-        grafanaOptions: JSON.parse(JSON.stringify(MOCK_GRAFANA_OPTIONS)),
-        authSettings: JSON.parse(JSON.stringify(MOCK_AUTH_SETTINGS)),
-        userPreferences: JSON.parse(JSON.stringify(MOCK_USER_PREFERENCES)),
+        log_time_options: JSON.parse(JSON.stringify(MOCK_LOG_TIME_OPTIONS)),
+        mail_settings: JSON.parse(JSON.stringify(MOCK_MAIL_SETTINGS)),
+        grafana_settings: JSON.parse(JSON.stringify(MOCK_GRAFANA_SETTINGS)),
+        grafana_options: JSON.parse(JSON.stringify(MOCK_GRAFANA_OPTIONS)),
+        auth_settings: JSON.parse(JSON.stringify(MOCK_AUTH_SETTINGS)),
+        user_preferences: JSON.parse(JSON.stringify(MOCK_USER_PREFERENCES)),
         layouts: JSON.parse(JSON.stringify(DEFAULT_LAYOUTS)),
-        layoutWidgets: JSON.parse(JSON.stringify(LAYOUT_WIDGETS)),
-        kpiData: JSON.parse(JSON.stringify(KPI_DATA)),
-        allColumns: JSON.parse(JSON.stringify(MOCK_ALL_COLUMNS)),
-        columnConfigs: {
+        layout_widgets: JSON.parse(JSON.stringify(LAYOUT_WIDGETS)),
+        kpi_data: JSON.parse(JSON.stringify(KPI_DATA)),
+        all_columns: JSON.parse(JSON.stringify(MOCK_ALL_COLUMNS)),
+        column_configs: {
             dashboards: ['name', 'type', 'category', 'owner', 'updated_at'],
             incidents: ['summary', 'status', 'severity', 'impact', 'resource', 'assignee', 'occurred_at'],
-            resources: ['status', 'name', 'type', 'provider', 'region', 'owner', 'lastCheckInAt'],
-            personnel: ['name', 'role', 'team', 'status', 'lastLoginAt'],
-            alert_rules: ['enabled', 'name', 'target', 'conditionsSummary', 'severity', 'automationEnabled', 'creator', 'updated_at'],
+            resources: ['status', 'name', 'type', 'provider', 'region', 'owner', 'last_check_in_at'],
+            personnel: ['name', 'role', 'team', 'status', 'last_login_at'],
+            alert_rules: ['enabled', 'name', 'target', 'conditions_summary', 'severity', 'automation_enabled', 'creator', 'updated_at'],
             silence_rules: ['enabled', 'name', 'type', 'matchers', 'schedule', 'creator', 'created_at'],
-            resource_groups: ['name', 'ownerTeam', 'memberIds', 'statusSummary'],
-            automation_playbooks: ['name', 'trigger', 'lastRunStatus', 'lastRunAt', 'runCount'],
-            automation_history: ['scriptName', 'status', 'triggerSource', 'triggeredBy', 'startTime', 'durationMs'],
-            automation_triggers: ['enabled', 'name', 'type', 'targetPlaybookId', 'lastTriggeredAt'],
-            teams: ['name', 'ownerId', 'memberIds', 'created_at'],
-            roles: ['enabled', 'name', 'userCount', 'created_at'],
+            resource_groups: ['name', 'owner_team', 'member_ids', 'status_summary'],
+            automation_playbooks: ['name', 'trigger', 'last_run_status', 'last_run_at', 'run_count'],
+            automation_history: ['script_name', 'status', 'trigger_source', 'triggered_by', 'start_time', 'duration_ms'],
+            automation_triggers: ['enabled', 'name', 'type', 'target_playbook_id', 'last_triggered_at'],
+            teams: ['name', 'owner_id', 'member_ids', 'created_at'],
+            roles: ['enabled', 'name', 'user_count', 'created_at'],
             audit_logs: ['timestamp', 'user', 'action', 'target', 'result'],
-            tag_management: ['key', 'description', 'enumValues', 'required', 'writableRoles'],
-            notification_strategies: ['enabled', 'name', 'triggerCondition', 'channelCount', 'severityLevels', 'impactLevels', 'creator', 'updated_at'],
+            tag_management: ['key', 'description', 'enum_values', 'required', 'writable_roles'],
+            notification_strategies: ['enabled', 'name', 'trigger_condition', 'channel_count', 'severity_levels', 'impact_levels', 'creator', 'updated_at'],
             datasources: ['name', 'type', 'status', 'url', 'created_at', 'updated_at'],
-            autodiscovery: ['name', 'kind', 'status', 'schedule', 'lastRunAt', 'created_at'],
-            notification_channels: ['enabled', 'name', 'type', 'lastTestResult', 'lastTestedAt'],
+            autodiscovery: ['name', 'kind', 'status', 'schedule', 'last_run_at', 'created_at'],
+            notification_channels: ['enabled', 'name', 'type', 'last_test_result', 'last_tested_at'],
             notification_history: ['timestamp', 'strategy', 'channel', 'recipient', 'status', 'content'],
         },
         // NEW DYNAMIC UI CONFIGS
-        tabConfigs: JSON.parse(JSON.stringify(MOCK_TAB_CONFIGS)),
-        platformSettings: JSON.parse(JSON.stringify(MOCK_PLATFORM_SETTINGS)),
-        preferenceOptions: JSON.parse(JSON.stringify(MOCK_PREFERENCE_OPTIONS)),
-        pageContent: JSON.parse(JSON.stringify(PAGE_CONTENT)),
-        commandPaletteContent: JSON.parse(JSON.stringify(MOCK_COMMAND_PALETTE_CONTENT)),
-        executionLogDetailContent: JSON.parse(JSON.stringify(MOCK_EXECUTION_LOG_DETAIL_CONTENT)),
-        importModalContent: JSON.parse(JSON.stringify(MOCK_IMPORT_MODAL_CONTENT)),
+        tab_configs: JSON.parse(JSON.stringify(MOCK_TAB_CONFIGS)),
+        platform_settings: JSON.parse(JSON.stringify(MOCK_PLATFORM_SETTINGS)),
+        preference_options: JSON.parse(JSON.stringify(MOCK_PREFERENCE_OPTIONS)),
+        page_content: JSON.parse(JSON.stringify(PAGE_CONTENT)),
+        command_palette_content: JSON.parse(JSON.stringify(MOCK_COMMAND_PALETTE_CONTENT)),
+        execution_log_detail_content: JSON.parse(JSON.stringify(MOCK_EXECUTION_LOG_DETAIL_CONTENT)),
+        import_modal_content: JSON.parse(JSON.stringify(MOCK_IMPORT_MODAL_CONTENT)),
         // AI DATA
-        aiBriefing: JSON.parse(JSON.stringify(MOCK_AI_BRIEFING)),
-        aiRiskPrediction: JSON.parse(JSON.stringify(MOCK_AI_RISK_PREDICTION)),
-        singleIncidentAnalysis: JSON.parse(JSON.stringify(MOCK_SINGLE_INCIDENT_ANALYSIS)),
-        multiIncidentAnalysis: JSON.parse(JSON.stringify(MOCK_MULTI_INCIDENT_ANALYSIS)),
-        alertRuleAnalysis: JSON.parse(JSON.stringify(MOCK_ALERT_RULE_ANALYSIS)),
-        silenceRuleAnalysis: JSON.parse(JSON.stringify(MOCK_SILENCE_RULE_ANALYSIS)),
-        generatedPlaybook: JSON.parse(JSON.stringify(MOCK_GENERATED_PLAYBOOK)),
-        logAnalysis: JSON.parse(JSON.stringify(MOCK_LOG_ANALYSIS)),
-        resourceAnalysis: JSON.parse(JSON.stringify(MOCK_RESOURCE_ANALYSIS)),
-        capacitySuggestions: JSON.parse(JSON.stringify(MOCK_CAPACITY_SUGGESTIONS)),
-        capacityResourceAnalysis: JSON.parse(JSON.stringify(MOCK_CAPACITY_RESOURCE_ANALYSIS)),
-        capacityTimeOptions: JSON.parse(JSON.stringify(MOCK_CAPACITY_TIME_OPTIONS)),
-        serviceHealthData: JSON.parse(JSON.stringify(MOCK_SERVICE_HEALTH_DATA)),
-        resourceGroupStatusData: JSON.parse(JSON.stringify(MOCK_RESOURCE_GROUP_STATUS_DATA)),
-        analysisOverviewData: JSON.parse(JSON.stringify(MOCK_ANALYSIS_OVERVIEW_DATA)),
+        ai_briefing: JSON.parse(JSON.stringify(MOCK_AI_BRIEFING)),
+        ai_risk_prediction: JSON.parse(JSON.stringify(MOCK_AI_RISK_PREDICTION)),
+        single_incident_analysis: JSON.parse(JSON.stringify(MOCK_SINGLE_INCIDENT_ANALYSIS)),
+        multi_incident_analysis: JSON.parse(JSON.stringify(MOCK_MULTI_INCIDENT_ANALYSIS)),
+        alert_rule_analysis: JSON.parse(JSON.stringify(MOCK_ALERT_RULE_ANALYSIS)),
+        silence_rule_analysis: JSON.parse(JSON.stringify(MOCK_SILENCE_RULE_ANALYSIS)),
+        generated_playbook: JSON.parse(JSON.stringify(MOCK_GENERATED_PLAYBOOK)),
+        log_analysis: JSON.parse(JSON.stringify(MOCK_LOG_ANALYSIS)),
+        resource_analysis: JSON.parse(JSON.stringify(MOCK_RESOURCE_ANALYSIS)),
+        capacity_suggestions: JSON.parse(JSON.stringify(MOCK_CAPACITY_SUGGESTIONS)),
+        capacity_resource_analysis: JSON.parse(JSON.stringify(MOCK_CAPACITY_RESOURCE_ANALYSIS)),
+        capacity_time_options: JSON.parse(JSON.stringify(MOCK_CAPACITY_TIME_OPTIONS)),
+        service_health_data: JSON.parse(JSON.stringify(MOCK_SERVICE_HEALTH_DATA)),
+        resource_group_status_data: JSON.parse(JSON.stringify(MOCK_RESOURCE_GROUP_STATUS_DATA)),
+        analysis_overview_data: JSON.parse(JSON.stringify(MOCK_ANALYSIS_OVERVIEW_DATA)),
         // Consolidated UI Options
-        allOptions: JSON.parse(JSON.stringify(MOCK_ALL_OPTIONS)),
+        all_options: JSON.parse(JSON.stringify(MOCK_ALL_OPTIONS)),
         // New Datasource/Discovery data
         datasources: JSON.parse(JSON.stringify(MOCK_DATASOURCES)),
-        discoveryJobs: JSON.parse(JSON.stringify(MOCK_DISCOVERY_JOBS)),
-        discoveredResources: JSON.parse(JSON.stringify(MOCK_DISCOVERED_RESOURCES)),
+        discovery_jobs: JSON.parse(JSON.stringify(MOCK_DISCOVERY_JOBS)),
+        discovered_resources: JSON.parse(JSON.stringify(MOCK_DISCOVERED_RESOURCES)),
     };
 }
 


### PR DESCRIPTION
## Summary
- convert the mock server datasets (incidents, alerts, resources, automation, notifications, discovery, etc.) to snake_case keys that match the updated schema
- align supporting configuration metadata and the initial DB export structure with snake_case so downstream consumers receive consistent property names

## Testing
- npm run build *(fails: rollup optional dependency @rollup/rollup-linux-x64-gnu is missing in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dcd4f9af24832db288e0a30bec9828