### PR TITLE
refactor: adopt snake case naming across frontend

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -147,7 +147,7 @@ const AppRoutes: React.FC = () => {
             <Route index element={<IncidentListPage />} />
             <Route path="rules" element={<AlertRulePage />} />
             <Route path="silence" element={<SilenceRulePage />} />
-            <Route path=":incidentId" element={<IncidentListPage />} />
+            <Route path=":incident_id" element={<IncidentListPage />} />
           </Route>
 
           <Route path="resources" element={<PageWithTabsLayout title={pageLayouts.resources.title} description={pageLayouts.resources.description} kpi_page_name={pageLayouts.resources.kpi_page_name} tabs={tabConfigs?.resources || []} />}>

--- a/components/AlertRuleEditModal.tsx
+++ b/components/AlertRuleEditModal.tsx
@@ -717,15 +717,15 @@ const AlertRuleEditModal: React.FC<AlertRuleEditModalProps> = ({ isOpen, onClose
 
     const handleSave = () => {
         const firstCondition = formData.condition_groups?.[0]?.conditions?.[0];
-        const conditionsSummary = firstCondition
+        const conditions_summary = firstCondition
             ? `${firstCondition.metric} ${firstCondition.operator} ${firstCondition.threshold}`
             : 'No conditions';
 
 
         const rulePayload: Partial<AlertRule> = {
             ...formData,
-            conditionsSummary: conditionsSummary,
-            automationEnabled: !!formData.automation?.enabled,
+            conditions_summary: conditions_summary,
+            automation_enabled: !!formData.automation?.enabled,
         };
 
         if (rule?.id) {

--- a/components/AutoDiscoveryEditModal.tsx
+++ b/components/AutoDiscoveryEditModal.tsx
@@ -35,9 +35,9 @@ const AutoDiscoveryEditModal: React.FC<AutoDiscoveryEditModalProps> = ({ isOpen,
   const kubeconfigInputRef = useRef<HTMLInputElement>(null);
   const { options, isLoading: isLoadingOptions } = useOptions();
   const autoDiscoveryOptions = options?.auto_discovery;
-  const exporterTemplates = autoDiscoveryOptions?.exporter_templates || [];
-  const mibProfiles = autoDiscoveryOptions?.mib_profiles || [];
-  const edgeGateways = autoDiscoveryOptions?.edge_gateways || [];
+  const exporter_templates = autoDiscoveryOptions?.exporter_templates || [];
+  const mib_profiles = autoDiscoveryOptions?.mib_profiles || [];
+  const edge_gateways = autoDiscoveryOptions?.edge_gateways || [];
 
   useEffect(() => {
     if (isOpen && autoDiscoveryOptions) {
@@ -109,7 +109,7 @@ const AutoDiscoveryEditModal: React.FC<AutoDiscoveryEditModalProps> = ({ isOpen,
     setFormData((prev) => ({
       ...prev,
       edge_gateway: enabled
-        ? { enabled, gateway_id: prev.edge_gateway?.gateway_id || edgeGateways[0]?.id }
+        ? { enabled, gateway_id: prev.edge_gateway?.gateway_id || edge_gateways[0]?.id }
         : { enabled },
     }));
   };
@@ -139,11 +139,11 @@ const AutoDiscoveryEditModal: React.FC<AutoDiscoveryEditModalProps> = ({ isOpen,
   };
 
   const handleSave = () => {
-    const exporterBinding: DiscoveryJobExporterBinding = formData.exporter_binding || { template_id: getDefaultTemplateForKind((formData.kind as DiscoveryJobKind) || 'K8s') };
+    const exporter_binding: DiscoveryJobExporterBinding = formData.exporter_binding || { template_id: getDefaultTemplateForKind((formData.kind as DiscoveryJobKind) || 'K8s') };
     const payload: Partial<DiscoveryJob> = {
       ...formData,
       target_config: formData.target_config || {},
-      exporter_binding: exporterBinding,
+      exporter_binding: exporter_binding,
       edge_gateway: formData.edge_gateway || { enabled: false },
       tags: formData.tags || [],
     };
@@ -265,8 +265,8 @@ const AutoDiscoveryEditModal: React.FC<AutoDiscoveryEditModalProps> = ({ isOpen,
 
   const renderExporterBindingSection = () => {
     const currentTemplateId = formData.exporter_binding?.template_id || 'none';
-    const templateMeta = exporterTemplates.find((tpl) => tpl.id === currentTemplateId);
-    const availableProfiles = mibProfiles.filter((profile) => profile.template_id === currentTemplateId);
+    const templateMeta = exporter_templates.find((tpl) => tpl.id === currentTemplateId);
+    const availableProfiles = mib_profiles.filter((profile) => profile.template_id === currentTemplateId);
 
     return (
       <div className="space-y-4">
@@ -278,7 +278,7 @@ const AutoDiscoveryEditModal: React.FC<AutoDiscoveryEditModalProps> = ({ isOpen,
             disabled={isLoadingOptions}
           >
             {isLoadingOptions && <option>載入中...</option>}
-            {exporterTemplates.map((tpl) => (
+            {exporter_templates.map((tpl) => (
               <option key={tpl.id} value={tpl.id}>
                 {tpl.name}
               </option>
@@ -337,14 +337,14 @@ const AutoDiscoveryEditModal: React.FC<AutoDiscoveryEditModalProps> = ({ isOpen,
             </label>
             {enabled && (
               <select
-                value={formData.edge_gateway?.gateway_id || edgeGateways[0]?.id || ''}
+                value={formData.edge_gateway?.gateway_id || edge_gateways[0]?.id || ''}
                 onChange={(e) => setFormData((prev) => ({
                   ...prev,
                   edge_gateway: { enabled: true, gateway_id: e.target.value },
                 }))}
                 className="bg-slate-800 border border-slate-700 rounded-md px-3 py-2 text-sm"
               >
-                {edgeGateways.map((gateway) => (
+                {edge_gateways.map((gateway) => (
                   <option key={gateway.id} value={gateway.id}>
                     {gateway.name}
                   </option>

--- a/components/ContextualKPICard.tsx
+++ b/components/ContextualKPICard.tsx
@@ -6,13 +6,13 @@ interface ContextualKPICardProps {
   value: string;
   description: React.ReactNode;
   icon: string;
-  iconBgColor: string;
+  icon_bg_color: string;
 }
 
-const ContextualKPICard: React.FC<ContextualKPICardProps> = ({ title, value, description, icon, iconBgColor }) => {
+const ContextualKPICard: React.FC<ContextualKPICardProps> = ({ title, value, description, icon, icon_bg_color }) => {
   return (
     <div className="glass-card rounded-xl p-5 flex items-center w-full">
-      <div className={`w-12 h-12 rounded-lg flex items-center justify-center mr-5 shrink-0 ${iconBgColor}`}>
+      <div className={`w-12 h-12 rounded-lg flex items-center justify-center mr-5 shrink-0 ${icon_bg_color}`}>
         <Icon name={icon} className="w-6 h-6 text-white" />
       </div>
       <div className="flex-1 min-w-0">

--- a/components/DiscoveryJobResultDrawer.tsx
+++ b/components/DiscoveryJobResultDrawer.tsx
@@ -25,8 +25,8 @@ const DiscoveryJobResultDrawer: React.FC<DiscoveryJobResultDrawerProps> = ({ job
     const [isImportModalOpen, setIsImportModalOpen] = useState(false);
     const { options } = useOptions();
     const autoDiscoveryOptions = options?.auto_discovery;
-    const exporterTemplates = autoDiscoveryOptions?.exporter_templates || [];
-    const edgeGateways = autoDiscoveryOptions?.edge_gateways || [];
+    const exporter_templates = autoDiscoveryOptions?.exporter_templates || [];
+    const edge_gateways = autoDiscoveryOptions?.edge_gateways || [];
 
     const fetchResults = useCallback(async () => {
         if (!job) return;
@@ -144,9 +144,9 @@ const DiscoveryJobResultDrawer: React.FC<DiscoveryJobResultDrawerProps> = ({ job
         );
     }
 
-    const templateMeta = exporterTemplates.find((tpl) => tpl.id === job.exporter_binding?.template_id);
+    const templateMeta = exporter_templates.find((tpl) => tpl.id === job.exporter_binding?.template_id);
     const gatewayLabel = job.edge_gateway?.enabled
-        ? edgeGateways.find((gw) => gw.id === job.edge_gateway?.gateway_id)?.name || job.edge_gateway?.gateway_id || '未指定'
+        ? edge_gateways.find((gw) => gw.id === job.edge_gateway?.gateway_id)?.name || job.edge_gateway?.gateway_id || '未指定'
         : '未啟用';
 
     const selectedResources = results.filter(r => selectedIds.includes(r.id));

--- a/components/ImportResourceModal.tsx
+++ b/components/ImportResourceModal.tsx
@@ -27,11 +27,11 @@ interface ImportResourceModalProps {
 const ImportResourceModal: React.FC<ImportResourceModalProps> = ({ isOpen, onClose, onSuccess, resourcesToImport, job }) => {
     const [isImporting, setIsImporting] = useState(false);
     const [importProgress, setImportProgress] = useState<ImportItemStatus[]>([]);
-    const [exporterBinding, setExporterBinding] = useState<DiscoveryJobExporterBinding | undefined>(job.exporter_binding);
+    const [exporter_binding, setExporterBinding] = useState<DiscoveryJobExporterBinding | undefined>(job.exporter_binding);
     const { options } = useOptions();
     const autoDiscoveryOptions = options?.auto_discovery;
-    const exporterTemplates = autoDiscoveryOptions?.exporter_templates || [];
-    const mibProfiles = autoDiscoveryOptions?.mib_profiles || [];
+    const exporter_templates = autoDiscoveryOptions?.exporter_templates || [];
+    const mib_profiles = autoDiscoveryOptions?.mib_profiles || [];
 
     useEffect(() => {
         if (isOpen) {
@@ -62,12 +62,12 @@ const ImportResourceModal: React.FC<ImportResourceModalProps> = ({ isOpen, onClo
             await api.post('/resources/import-discovered', {
                 discovered_resource_ids: resourcesToImport.map((r) => r.id),
                 job_id: job.id,
-                exporter_binding: exporterBinding,
+                exporter_binding: exporter_binding,
             });
 
             for (let i = 0; i < resourcesToImport.length; i++) {
                 const resource = resourcesToImport[i];
-                if (exporterBinding && exporterBinding.template_id !== 'none') {
+                if (exporter_binding && exporter_binding.template_id !== 'none') {
                     await new Promise((r) => setTimeout(r, 500));
                     setImportProgress((prev) => prev.map((p) => (p.id === resource.id ? { ...p, status: 'deploying' } : p)));
                 }
@@ -116,9 +116,9 @@ const ImportResourceModal: React.FC<ImportResourceModalProps> = ({ isOpen, onClo
         }
     };
 
-    const currentTemplateId = exporterBinding?.template_id || job.exporter_binding?.template_id || 'none';
-    const templateMeta = exporterTemplates.find((tpl) => tpl.id === currentTemplateId);
-    const availableProfiles = mibProfiles.filter((profile) => profile.template_id === currentTemplateId);
+    const currentTemplateId = exporter_binding?.template_id || job.exporter_binding?.template_id || 'none';
+    const templateMeta = exporter_templates.find((tpl) => tpl.id === currentTemplateId);
+    const availableProfiles = mib_profiles.filter((profile) => profile.template_id === currentTemplateId);
 
     return (
         <Modal
@@ -168,12 +168,12 @@ const ImportResourceModal: React.FC<ImportResourceModalProps> = ({ isOpen, onClo
                             onChange={(e) => handleExporterBindingChange({ template_id: e.target.value as DiscoveryJobExporterBinding['template_id'] })}
                             className="w-full bg-slate-800 border border-slate-700 rounded-md px-3 py-2 text-sm"
                         >
-                            {exporterTemplates.map((tpl) => (
+                            {exporter_templates.map((tpl) => (
                                 <option key={tpl.id} value={tpl.id}>
                                     {tpl.name}
                                 </option>
                             ))}
-                            {exporterTemplates.length === 0 && <option value="none">none</option>}
+                            {exporter_templates.length === 0 && <option value="none">none</option>}
                         </select>
                         {templateMeta?.description && <p className="mt-1 text-xs text-slate-400">{templateMeta.description}</p>}
                     </FormRow>
@@ -181,7 +181,7 @@ const ImportResourceModal: React.FC<ImportResourceModalProps> = ({ isOpen, onClo
                     {templateMeta?.supports_mib_profile && (
                         <FormRow label="MIB Profile">
                             <select
-                                value={exporterBinding?.mib_profile_id || ''}
+                                value={exporter_binding?.mib_profile_id || ''}
                                 onChange={(e) => handleExporterBindingChange({ mib_profile_id: e.target.value || undefined })}
                                 className="w-full bg-slate-800 border border-slate-700 rounded-md px-3 py-2 text-sm"
                             >
@@ -202,7 +202,7 @@ const ImportResourceModal: React.FC<ImportResourceModalProps> = ({ isOpen, onClo
                         <FormRow label="自訂覆寫 YAML">
                             <textarea
                                 rows={3}
-                                value={exporterBinding?.overrides_yaml || ''}
+                                value={exporter_binding?.overrides_yaml || ''}
                                 onChange={(e) => handleExporterBindingChange({ overrides_yaml: e.target.value })}
                                 className="w-full bg-slate-800 border border-slate-700 rounded-md px-3 py-2 text-sm font-mono"
                                 disabled={isImporting}

--- a/components/NotificationStrategyEditModal.tsx
+++ b/components/NotificationStrategyEditModal.tsx
@@ -115,17 +115,17 @@ const NotificationStrategyEditModal: React.FC<NotificationStrategyEditModalProps
         const additionalCondition = serializeConditions(additionalConditions);
         const finalCondition = [groupCondition, additionalCondition].filter(Boolean).join(' AND ');
 
-        const severityLevels = (formData.severity_levels && formData.severity_levels.length > 0)
+        const severity_levels = (formData.severity_levels && formData.severity_levels.length > 0)
             ? formData.severity_levels
             : strategyOptions?.severity_levels ?? [];
-        const impactLevels = (formData.impact_levels && formData.impact_levels.length > 0)
+        const impact_levels = (formData.impact_levels && formData.impact_levels.length > 0)
             ? formData.impact_levels
             : strategyOptions?.impact_levels ?? [];
 
         onSave({
             ...formData,
-            severity_levels: severityLevels,
-            impact_levels: impactLevels,
+            severity_levels: severity_levels,
+            impact_levels: impact_levels,
             trigger_condition: finalCondition
         } as NotificationStrategy);
     };

--- a/components/PageKPIs.tsx
+++ b/components/PageKPIs.tsx
@@ -6,25 +6,25 @@ import api from '../services/api';
 
 interface PageKPIsProps {
   pageName: string;
-  widgetIds?: string[];
+  widget_ids?: string[];
 }
 
 interface KpiDataItem {
     value: string;
     description: string;
     icon: string;
-    iconBgColor: string;
+    icon_bg_color: string;
 }
 
 interface LayoutsData {
     [key: string]: {
-        widgetIds: string[];
-        updatedAt: string;
-        updatedBy: string;
+        widget_ids: string[];
+        updated_at: string;
+        updated_by: string;
     }
 }
 
-const PageKPIs: React.FC<PageKPIsProps> = ({ pageName, widgetIds: explicitWidgetIds }) => {
+const PageKPIs: React.FC<PageKPIsProps> = ({ pageName, widget_ids: explicit_widget_ids }) => {
   const [layouts, setLayouts] = useState<LayoutsData>({});
   const [kpiData, setKpiData] = useState<Record<string, KpiDataItem>>({});
   const [widgets, setWidgets] = useState<LayoutWidget[]>([]);
@@ -68,7 +68,7 @@ const PageKPIs: React.FC<PageKPIsProps> = ({ pageName, widgetIds: explicitWidget
     return () => window.removeEventListener('storage', handleStorageChange);
   }, []);
 
-  const widgetIds = explicitWidgetIds || layouts[pageName]?.widgetIds || [];
+  const widget_ids = explicit_widget_ids || layouts[pageName]?.widget_ids || [];
 
   if (isLoading) {
     return (
@@ -81,7 +81,7 @@ const PageKPIs: React.FC<PageKPIsProps> = ({ pageName, widgetIds: explicitWidget
     );
   }
 
-  if (widgetIds.length === 0) {
+  if (widget_ids.length === 0) {
     return (
       <div className="rounded-lg border border-dashed border-slate-700 bg-slate-900/40 p-8 text-center text-slate-400">
         <Icon name="layout-dashboard" className="w-6 h-6 mx-auto mb-3" />
@@ -118,7 +118,7 @@ const PageKPIs: React.FC<PageKPIsProps> = ({ pageName, widgetIds: explicitWidget
 
   return (
     <div className="grid grid-cols-[repeat(auto-fit,minmax(260px,1fr))] gap-4 mb-6">
-      {widgetIds.map(id => {
+      {widget_ids.map(id => {
         const widget = getWidgetById(id);
         const data = kpiData[id];
         if (!widget || !data) {
@@ -138,7 +138,7 @@ const PageKPIs: React.FC<PageKPIsProps> = ({ pageName, widgetIds: explicitWidget
             value={data.value}
             description={renderDescription(data.description)}
             icon={data.icon}
-            iconBgColor={data.iconBgColor}
+            icon_bg_color={data.icon_bg_color}
           />
         );
       })}

--- a/components/QuickSilenceModal.tsx
+++ b/components/QuickSilenceModal.tsx
@@ -7,7 +7,7 @@ import { useOptions } from '../contexts/OptionsContext';
 interface QuickSilenceModalProps {
   isOpen: boolean;
   onClose: () => void;
-  onSave: (incidentId: string, durationHours: number) => void;
+  onSave: (incident_id: string, durationHours: number) => void;
   incident: Incident | null;
 }
 
@@ -31,8 +31,8 @@ const QuickSilenceModal: React.FC<QuickSilenceModalProps> = ({ isOpen, onClose, 
   };
 
   const getEndTime = () => {
-    const endTime = new Date(Date.now() + duration * 3600 * 1000);
-    return endTime.toLocaleString('zh-TW', {
+    const end_time = new Date(Date.now() + duration * 3600 * 1000);
+    return end_time.toLocaleString('zh-TW', {
       year: 'numeric',
       month: '2-digit',
       day: '2-digit',

--- a/components/SilenceRuleEditModal.tsx
+++ b/components/SilenceRuleEditModal.tsx
@@ -323,12 +323,12 @@ const Step3 = ({ formData, setFormData, options }: { formData: Partial<SilenceRu
     }, [formData.matchers]);
 
     const renderMatcherValueInput = (matcher: SilenceMatcher, index: number) => {
-        const allowedValues = options?.values[matcher.key] || [];
+        const allowed_values = options?.values[matcher.key] || [];
 
-        if (allowedValues.length > 0) {
+        if (allowed_values.length > 0) {
             return (
                 <MultiSelectDropdown
-                    options={allowedValues.map(v => ({ id: v, value: v }))}
+                    options={allowed_values.map(v => ({ id: v, value: v }))}
                     selectedValues={matcher.value ? matcher.value.split('|') : []}
                     onChange={(newValues) => {
                         const newMatchers = JSON.parse(JSON.stringify(formData.matchers || []));

--- a/components/TeamEditModal.tsx
+++ b/components/TeamEditModal.tsx
@@ -39,7 +39,7 @@ const UserListItem: React.FC<UserListItemProps> = ({ user, onAction, iconName })
 const TeamEditModal: React.FC<TeamEditModalProps> = ({ isOpen, onClose, onSave, team }) => {
     const [name, setName] = useState('');
     const [description, setDescription] = useState('');
-    const [ownerId, setOwnerId] = useState('');
+    const [owner_id, setOwnerId] = useState('');
     const [memberIds, setMemberIds] = useState<string[]>([]);
     const [allUsers, setAllUsers] = useState<User[]>([]);
     const [isLoading, setIsLoading] = useState(false);
@@ -69,7 +69,7 @@ const TeamEditModal: React.FC<TeamEditModalProps> = ({ isOpen, onClose, onSave, 
             id: team?.id || '',
             name,
             description,
-            owner_id: ownerId,
+            owner_id: owner_id,
             member_ids: memberIds,
             created_at: team?.created_at || '',
             updated_at: new Date().toISOString(),
@@ -99,7 +99,7 @@ const TeamEditModal: React.FC<TeamEditModalProps> = ({ isOpen, onClose, onSave, 
                         <input type="text" value={name} onChange={e => setName(e.target.value)} className="w-full bg-slate-800 border border-slate-700 rounded-md px-3 py-2 text-sm" />
                     </FormRow>
                     <FormRow label="擁有者">
-                        <select value={ownerId} onChange={e => setOwnerId(e.target.value)} className="w-full bg-slate-800 border border-slate-700 rounded-md px-3 py-2 text-sm">
+                        <select value={owner_id} onChange={e => setOwnerId(e.target.value)} className="w-full bg-slate-800 border border-slate-700 rounded-md px-3 py-2 text-sm">
                             {allUsers.map(u => <option key={u.id} value={u.id}>{u.name}</option>)}
                         </select>
                     </FormRow>

--- a/components/UnifiedSearchModal.tsx
+++ b/components/UnifiedSearchModal.tsx
@@ -17,8 +17,8 @@ export interface IncidentFilters {
   severity?: IncidentSeverity;
   impact?: IncidentImpact;
   assignee?: string;
-  startTime?: string;
-  endTime?: string;
+  start_time?: string;
+  end_time?: string;
 }
 
 export interface AlertRuleFilters {
@@ -127,8 +127,8 @@ const UnifiedSearchModal: React.FC<UnifiedSearchModalProps> = ({ page, isOpen, o
       <div className="col-span-2">
         <FormRow label={content.INCIDENTS.TRIGGER_TIME_RANGE}>
           <div className="flex space-x-2">
-            <input type="datetime-local" value={(filters as IncidentFilters).startTime || ''} onChange={e => setFilters(prev => ({ ...(prev as IncidentFilters), startTime: e.target.value }))} className="w-full bg-slate-800 border border-slate-700 rounded-md px-3 py-2 text-sm" />
-            <input type="datetime-local" value={(filters as IncidentFilters).endTime || ''} onChange={e => setFilters(prev => ({ ...(prev as IncidentFilters), endTime: e.target.value }))} className="w-full bg-slate-800 border border-slate-700 rounded-md px-3 py-2 text-sm" />
+            <input type="datetime-local" value={(filters as IncidentFilters).start_time || ''} onChange={e => setFilters(prev => ({ ...(prev as IncidentFilters), start_time: e.target.value }))} className="w-full bg-slate-800 border border-slate-700 rounded-md px-3 py-2 text-sm" />
+            <input type="datetime-local" value={(filters as IncidentFilters).end_time || ''} onChange={e => setFilters(prev => ({ ...(prev as IncidentFilters), end_time: e.target.value }))} className="w-full bg-slate-800 border border-slate-700 rounded-md px-3 py-2 text-sm" />
           </div>
         </FormRow>
       </div>
@@ -230,8 +230,8 @@ const UnifiedSearchModal: React.FC<UnifiedSearchModalProps> = ({ page, isOpen, o
       <div className="col-span-2">
         <FormRow label={content.AUDIT_LOGS.TIME_RANGE}>
           <div className="flex space-x-2">
-            <input type="datetime-local" value={(filters as AuditLogFilters).start_date || ''} onChange={e => setFilters(prev => ({ ...(prev as AuditLogFilters), startDate: e.target.value }))} className="w-full bg-slate-800 border border-slate-700 rounded-md px-3 py-2 text-sm" />
-            <input type="datetime-local" value={(filters as AuditLogFilters).end_date || ''} onChange={e => setFilters(prev => ({ ...(prev as AuditLogFilters), endDate: e.target.value }))} className="w-full bg-slate-800 border border-slate-700 rounded-md px-3 py-2 text-sm" />
+            <input type="datetime-local" value={(filters as AuditLogFilters).start_date || ''} onChange={e => setFilters(prev => ({ ...(prev as AuditLogFilters), start_date: e.target.value }))} className="w-full bg-slate-800 border border-slate-700 rounded-md px-3 py-2 text-sm" />
+            <input type="datetime-local" value={(filters as AuditLogFilters).end_date || ''} onChange={e => setFilters(prev => ({ ...(prev as AuditLogFilters), end_date: e.target.value }))} className="w-full bg-slate-800 border border-slate-700 rounded-md px-3 py-2 text-sm" />
           </div>
         </FormRow>
       </div>
@@ -252,7 +252,7 @@ const UnifiedSearchModal: React.FC<UnifiedSearchModalProps> = ({ page, isOpen, o
   const renderAutomationHistoryFilters = () => (
     <>
       <FormRow label={content.AUTOMATION_HISTORY.PLAYBOOK}>
-        <select value={(filters as AutomationHistoryFilters).playbook_id || ''} onChange={e => setFilters(prev => ({ ...prev, playbookId: e.target.value }))} className="w-full bg-slate-800 border border-slate-700 rounded-md px-3 py-2 text-sm">
+        <select value={(filters as AutomationHistoryFilters).playbook_id || ''} onChange={e => setFilters(prev => ({ ...prev, playbook_id: e.target.value }))} className="w-full bg-slate-800 border border-slate-700 rounded-md px-3 py-2 text-sm">
           <option value="">{content.AUTOMATION_HISTORY.ALL_PLAYBOOKS}</option>
           {playbooks.map(p => <option key={p.id} value={p.id}>{p.name}</option>)}
         </select>
@@ -266,8 +266,8 @@ const UnifiedSearchModal: React.FC<UnifiedSearchModalProps> = ({ page, isOpen, o
       <div className="col-span-2">
         <FormRow label={content.AUTOMATION_HISTORY.TIME_RANGE}>
           <div className="flex space-x-2">
-            <input type="datetime-local" value={(filters as AutomationHistoryFilters).start_date || ''} onChange={e => setFilters(prev => ({ ...prev, startDate: e.target.value }))} className="w-full bg-slate-800 border border-slate-700 rounded-md px-3 py-2 text-sm" />
-            <input type="datetime-local" value={(filters as AutomationHistoryFilters).end_date || ''} onChange={e => setFilters(prev => ({ ...prev, endDate: e.target.value }))} className="w-full bg-slate-800 border border-slate-700 rounded-md px-3 py-2 text-sm" />
+            <input type="datetime-local" value={(filters as AutomationHistoryFilters).start_date || ''} onChange={e => setFilters(prev => ({ ...prev, start_date: e.target.value }))} className="w-full bg-slate-800 border border-slate-700 rounded-md px-3 py-2 text-sm" />
+            <input type="datetime-local" value={(filters as AutomationHistoryFilters).end_date || ''} onChange={e => setFilters(prev => ({ ...prev, end_date: e.target.value }))} className="w-full bg-slate-800 border border-slate-700 rounded-md px-3 py-2 text-sm" />
           </div>
         </FormRow>
       </div>
@@ -283,7 +283,7 @@ const UnifiedSearchModal: React.FC<UnifiedSearchModalProps> = ({ page, isOpen, o
         </select>
       </FormRow>
       <FormRow label={content.NOTIFICATION_HISTORY.CHANNEL_TYPE}>
-        <select value={(filters as NotificationHistoryFilters).channel_type || ''} onChange={e => setFilters(prev => ({ ...prev, channelType: e.target.value as any }))} className="w-full bg-slate-800 border border-slate-700 rounded-md px-3 py-2 text-sm">
+        <select value={(filters as NotificationHistoryFilters).channel_type || ''} onChange={e => setFilters(prev => ({ ...prev, channel_type: e.target.value as any }))} className="w-full bg-slate-800 border border-slate-700 rounded-md px-3 py-2 text-sm">
           <option value="">{content.NOTIFICATION_HISTORY.ALL_CHANNEL_TYPES}</option>
           {options?.notification_history.channel_types.map(c => <option key={c.value} value={c.value}>{c.label}</option>)}
         </select>
@@ -291,8 +291,8 @@ const UnifiedSearchModal: React.FC<UnifiedSearchModalProps> = ({ page, isOpen, o
       <div className="col-span-2">
         <FormRow label={content.NOTIFICATION_HISTORY.TIME_RANGE}>
           <div className="flex space-x-2">
-            <input type="datetime-local" value={(filters as NotificationHistoryFilters).start_date || ''} onChange={e => setFilters(prev => ({ ...prev, startDate: e.target.value }))} className="w-full bg-slate-800 border border-slate-700 rounded-md px-3 py-2 text-sm" />
-            <input type="datetime-local" value={(filters as NotificationHistoryFilters).end_date || ''} onChange={e => setFilters(prev => ({ ...prev, endDate: e.target.value }))} className="w-full bg-slate-800 border border-slate-700 rounded-md px-3 py-2 text-sm" />
+            <input type="datetime-local" value={(filters as NotificationHistoryFilters).start_date || ''} onChange={e => setFilters(prev => ({ ...prev, start_date: e.target.value }))} className="w-full bg-slate-800 border border-slate-700 rounded-md px-3 py-2 text-sm" />
+            <input type="datetime-local" value={(filters as NotificationHistoryFilters).end_date || ''} onChange={e => setFilters(prev => ({ ...prev, end_date: e.target.value }))} className="w-full bg-slate-800 border border-slate-700 rounded-md px-3 py-2 text-sm" />
           </div>
         </FormRow>
       </div>

--- a/mock-server/handlers.ts
+++ b/mock-server/handlers.ts
@@ -11,11 +11,11 @@ const getActive = (collection: any[] | undefined) => {
     return collection.filter(item => !item.deleted_at);
 }
 
-const validateEnum = <T>(value: any, allowedValues: T[], fieldName: string): T => {
-    if (!allowedValues.includes(value as T)) {
+const validateEnum = <T>(value: any, allowed_values: T[], fieldName: string): T => {
+    if (!allowed_values.includes(value as T)) {
         throw {
             status: 400,
-            message: `Invalid ${fieldName}. Allowed values: ${allowedValues.join(', ')}`
+            message: `Invalid ${fieldName}. Allowed values: ${allowed_values.join(', ')}`
         };
     }
     return value as T;
@@ -64,7 +64,7 @@ const sortData = (data: any[], sortBy: string, sortOrder: 'asc' | 'desc') => {
 
 /**
  * 自動填充 team 和 owner 標籤（從關聯實體自動生成）
- * @param entity 實體物件（需要有 teamId 和/或 ownerId 欄位）
+ * @param entity 實體物件（需要有 team_id 和/或 owner_id 欄位）
  */
 const autoPopulateReadonlyTags = (entity: any): void => {
     if (!entity.tags) {
@@ -761,9 +761,9 @@ const handleRequest = async (method: HttpMethod, url: string, params: any, body:
                     };
                 }
                 if (subId === 'test') {
-                    const ruleId = id;
+                    const rule_id = id;
                     const { payload } = body;
-                    const rule = DB.alert_rules.find((r: any) => r.id === ruleId);
+                    const rule = DB.alert_rules.find((r: any) => r.id === rule_id);
                     if (!rule) throw { status: 404, message: 'Rule not found' };
                     const condition = rule.condition_groups?.[0]?.conditions?.[0];
                     if (condition && payload.metric === condition.metric && payload.value > condition.threshold) {
@@ -889,8 +889,8 @@ const handleRequest = async (method: HttpMethod, url: string, params: any, body:
                     if (!Array.isArray(ids)) {
                         throw { status: 400, message: 'Invalid payload for batch actions.' };
                     }
-                    ids.forEach((ruleId: string) => {
-                        const ruleIndex = DB.silenceRules.findIndex((rule: any) => rule.id === ruleId);
+                    ids.forEach((rule_id: string) => {
+                        const ruleIndex = DB.silenceRules.findIndex((rule: any) => rule.id === rule_id);
                         if (ruleIndex === -1) return;
                         if (action === 'delete') {
                             DB.silenceRules.splice(ruleIndex, 1);
@@ -1318,8 +1318,8 @@ const handleRequest = async (method: HttpMethod, url: string, params: any, body:
                     return DB.datasources[index];
                 }
                 if (id === 'discovery-jobs') {
-                    const jobId = subId;
-                    const index = DB.discovery_jobs.findIndex((j: any) => j.id === jobId);
+                    const job_id = subId;
+                    const index = DB.discovery_jobs.findIndex((j: any) => j.id === job_id);
                     if (index === -1) throw { status: 404 };
                     const existingJob = DB.discovery_jobs[index];
                     // 更新 updated_at 時間戳
@@ -1382,8 +1382,8 @@ const handleRequest = async (method: HttpMethod, url: string, params: any, body:
                     return {};
                 }
                 if (id === 'discovery-jobs') {
-                    const jobId = subId;
-                    const index = DB.discovery_jobs.findIndex((j: any) => j.id === jobId);
+                    const job_id = subId;
+                    const index = DB.discovery_jobs.findIndex((j: any) => j.id === job_id);
                     if (index > -1) (DB.discovery_jobs[index] as any).deleted_at = new Date().toISOString();
                     return {};
                 }
@@ -1563,15 +1563,15 @@ const handleRequest = async (method: HttpMethod, url: string, params: any, body:
                         return { success: true, updated };
                     }
                     if (action === 'execute') {
-                        const scriptId = subId;
-                        if (!scriptId) {
+                        const script_id = subId;
+                        if (!script_id) {
                             throw { status: 400, message: 'Script ID is required to execute an automation playbook.' };
                         }
-                        const script = DB.playbooks.find((p: any) => p.id === scriptId);
+                        const script = DB.playbooks.find((p: any) => p.id === script_id);
                         if (!script) throw { status: 404, message: 'Automation playbook not found.' };
                         const newExec = {
                             id: `exec-${uuidv4()}`,
-                            script_id: scriptId,
+                            script_id: script_id,
                             script_name: script.name,
                             status: 'running',
                             trigger_source: 'manual',
@@ -2277,10 +2277,10 @@ const handleRequest = async (method: HttpMethod, url: string, params: any, body:
                 }
                 if (id === 'notification-strategies') {
                     const fallbackOptions = DB.notification_strategy_options || { severity_levels: [], impact_levels: [] };
-                    const severityLevels = Array.isArray(body?.severity_levels) && body.severity_levels.length > 0
+                    const severity_levels = Array.isArray(body?.severity_levels) && body.severity_levels.length > 0
                         ? body.severity_levels
                         : fallbackOptions.severity_levels;
-                    const impactLevels = Array.isArray(body?.impact_levels) && body.impact_levels.length > 0
+                    const impact_levels = Array.isArray(body?.impact_levels) && body.impact_levels.length > 0
                         ? body.impact_levels
                         : fallbackOptions.impact_levels;
 
@@ -2290,8 +2290,8 @@ const handleRequest = async (method: HttpMethod, url: string, params: any, body:
                         id: `strat-${uuidv4()}`,
                         last_updated: timestamp,
                         creator: 'Admin User',
-                        severity_levels: severityLevels,
-                        impact_levels: impactLevels,
+                        severity_levels: severity_levels,
+                        impact_levels: impact_levels,
                         channel_count: body?.channel_count ?? 0,
                         enabled: body?.enabled ?? true,
                         created_at: timestamp,
@@ -2375,10 +2375,10 @@ const handleRequest = async (method: HttpMethod, url: string, params: any, body:
                     const index = DB.notification_strategies.findIndex((s: any) => s.id === itemId);
                     if (index === -1) throw { status: 404 };
                     const existingStrategy = DB.notification_strategies[index];
-                    const severityLevels = Array.isArray(body?.severity_levels) && body?.severity_levels.length > 0
+                    const severity_levels = Array.isArray(body?.severity_levels) && body?.severity_levels.length > 0
                         ? body.severity_levels
                         : existingStrategy.severity_levels;
-                    const impactLevels = Array.isArray(body?.impact_levels) && body?.impact_levels.length > 0
+                    const impact_levels = Array.isArray(body?.impact_levels) && body?.impact_levels.length > 0
                         ? body.impact_levels
                         : existingStrategy.impact_levels;
 
@@ -2386,8 +2386,8 @@ const handleRequest = async (method: HttpMethod, url: string, params: any, body:
                     DB.notification_strategies[index] = {
                         ...existingStrategy,
                         ...body,
-                        severity_levels: severityLevels,
-                        impact_levels: impactLevels,
+                        severity_levels: severity_levels,
+                        impact_levels: impact_levels,
                         last_updated: timestamp,
                         updated_at: timestamp
                     };

--- a/pages/DashboardViewPage.tsx
+++ b/pages/DashboardViewPage.tsx
@@ -56,7 +56,7 @@ const DashboardViewPage: React.FC = () => {
     }
     // Handle generic, user-created built-in dashboards that have a layout property
     if (dashboard.layout) {
-      return <GenericBuiltInDashboardPage name={dashboard.name} description={dashboard.description} widgetIds={dashboard.layout} />;
+      return <GenericBuiltInDashboardPage name={dashboard.name} description={dashboard.description} widget_ids={dashboard.layout} />;
     }
     // Fallback for any other built-in dashboard without a specific page or layout
     return <Navigate to="/home" replace />;

--- a/pages/analysis/CapacityPlanningPage.tsx
+++ b/pages/analysis/CapacityPlanningPage.tsx
@@ -65,14 +65,14 @@ const CapacityPlanningPage: React.FC = () => {
         fetchData();
     }, [fetchData]);
 
-    const seriesLabels = useMemo(
+    const series_labels = useMemo(
         () => ({
             cpu: content?.SERIES_LABELS?.CPU ?? 'CPU',
-            cpuForecast: content?.SERIES_LABELS?.CPU_FORECAST ?? 'CPU Forecast',
+            cpu_forecast: content?.SERIES_LABELS?.CPU_FORECAST ?? 'CPU Forecast',
             memory: content?.SERIES_LABELS?.MEMORY ?? 'Memory',
-            memoryForecast: content?.SERIES_LABELS?.MEMORY_FORECAST ?? 'Memory Forecast',
+            memory_forecast: content?.SERIES_LABELS?.MEMORY_FORECAST ?? 'Memory Forecast',
             storage: content?.SERIES_LABELS?.STORAGE ?? 'Storage',
-            storageForecast: content?.SERIES_LABELS?.STORAGE_FORECAST ?? 'Storage Forecast',
+            storage_forecast: content?.SERIES_LABELS?.STORAGE_FORECAST ?? 'Storage Forecast',
         }),
         [content],
     );
@@ -82,12 +82,12 @@ const CapacityPlanningPage: React.FC = () => {
             tooltip: { trigger: 'axis' },
             legend: {
                 data: [
-                    seriesLabels.cpu,
-                    seriesLabels.cpuForecast,
-                    seriesLabels.memory,
-                    seriesLabels.memoryForecast,
-                    seriesLabels.storage,
-                    seriesLabels.storageForecast,
+                    series_labels.cpu,
+                    series_labels.cpu_forecast,
+                    series_labels.memory,
+                    series_labels.memory_forecast,
+                    series_labels.storage,
+                    series_labels.storage_forecast,
                 ],
                 textStyle: { color: chartTheme.text.primary },
             },
@@ -101,21 +101,21 @@ const CapacityPlanningPage: React.FC = () => {
                 splitLine: { lineStyle: { color: chartTheme.grid.split_line } },
             },
             series: [
-                { name: seriesLabels.cpu, type: 'line', data: data?.trends.cpu.historical, showSymbol: false, lineStyle: { color: chartTheme.capacity_planning.cpu } },
-                { name: seriesLabels.cpuForecast, type: 'line', data: data?.trends.cpu.forecast, showSymbol: false, lineStyle: { type: 'dashed', color: chartTheme.capacity_planning.cpu } },
-                { name: seriesLabels.memory, type: 'line', data: data?.trends.memory.historical, showSymbol: false, lineStyle: { color: chartTheme.capacity_planning.memory } },
-                { name: seriesLabels.memoryForecast, type: 'line', data: data?.trends.memory.forecast, showSymbol: false, lineStyle: { type: 'dashed', color: chartTheme.capacity_planning.memory } },
-                { name: seriesLabels.storage, type: 'line', data: data?.trends.storage.historical, showSymbol: false, lineStyle: { color: chartTheme.capacity_planning.storage } },
-                { name: seriesLabels.storageForecast, type: 'line', data: data?.trends.storage.forecast, showSymbol: false, lineStyle: { type: 'dashed', color: chartTheme.capacity_planning.storage } },
+                { name: series_labels.cpu, type: 'line', data: data?.trends.cpu.historical, showSymbol: false, lineStyle: { color: chartTheme.capacity_planning.cpu } },
+                { name: series_labels.cpu_forecast, type: 'line', data: data?.trends.cpu.forecast, showSymbol: false, lineStyle: { type: 'dashed', color: chartTheme.capacity_planning.cpu } },
+                { name: series_labels.memory, type: 'line', data: data?.trends.memory.historical, showSymbol: false, lineStyle: { color: chartTheme.capacity_planning.memory } },
+                { name: series_labels.memory_forecast, type: 'line', data: data?.trends.memory.forecast, showSymbol: false, lineStyle: { type: 'dashed', color: chartTheme.capacity_planning.memory } },
+                { name: series_labels.storage, type: 'line', data: data?.trends.storage.historical, showSymbol: false, lineStyle: { color: chartTheme.capacity_planning.storage } },
+                { name: series_labels.storage_forecast, type: 'line', data: data?.trends.storage.forecast, showSymbol: false, lineStyle: { type: 'dashed', color: chartTheme.capacity_planning.storage } },
             ],
         }),
-        [chartTheme, data, seriesLabels],
+        [chartTheme, data, series_labels],
     );
 
-    const forecastModelLegend = useMemo(
+    const forecast_model_legend = useMemo(
         () => ({
             prediction: content?.FORECAST_MODEL_LEGEND?.PREDICTION ?? '預測',
-            confidenceBand: content?.FORECAST_MODEL_LEGEND?.CONFIDENCE_BAND ?? '信賴區間',
+            confidence_band: content?.FORECAST_MODEL_LEGEND?.CONFIDENCE_BAND ?? '信賴區間',
         }),
         [content],
     );
@@ -123,7 +123,7 @@ const CapacityPlanningPage: React.FC = () => {
     const forecastModelOption = useMemo(
         () => ({
             tooltip: { trigger: 'axis' },
-            legend: { data: [forecastModelLegend.prediction, forecastModelLegend.confidenceBand], textStyle: { color: chartTheme.text.primary } },
+            legend: { data: [forecast_model_legend.prediction, forecast_model_legend.confidence_band], textStyle: { color: chartTheme.text.primary } },
             grid: { left: '3%', right: '4%', bottom: '3%', containLabel: true },
             xAxis: { type: 'time', axisLine: { lineStyle: { color: chartTheme.grid.axis } } },
             yAxis: {
@@ -134,10 +134,10 @@ const CapacityPlanningPage: React.FC = () => {
                 splitLine: { lineStyle: { color: chartTheme.grid.split_line } },
             },
             series: [
-                { name: forecastModelLegend.prediction, type: 'line', data: data?.forecast_model.prediction, showSymbol: false, lineStyle: { color: chartTheme.capacity_planning.forecast } },
-                { name: forecastModelLegend.confidenceBand, type: 'line', data: data?.forecast_model.confidence_band[0], lineStyle: { opacity: 0 }, stack: 'confidence-band', symbol: 'none' },
+                { name: forecast_model_legend.prediction, type: 'line', data: data?.forecast_model.prediction, showSymbol: false, lineStyle: { color: chartTheme.capacity_planning.forecast } },
+                { name: forecast_model_legend.confidence_band, type: 'line', data: data?.forecast_model.confidence_band[0], lineStyle: { opacity: 0 }, stack: 'confidence-band', symbol: 'none' },
                 {
-                    name: forecastModelLegend.confidenceBand,
+                    name: forecast_model_legend.confidence_band,
                     type: 'line',
                     data: data
                         ? data.forecast_model.confidence_band[1].map((point, i) => [point[0], point[1] - data.forecast_model.confidence_band[0][i][1]])
@@ -149,7 +149,7 @@ const CapacityPlanningPage: React.FC = () => {
                 },
             ],
         }),
-        [chartTheme, data, toRgba, forecastModelLegend],
+        [chartTheme, data, toRgba, forecast_model_legend],
     );
 
     const handleExport = () => {
@@ -160,13 +160,13 @@ const CapacityPlanningPage: React.FC = () => {
         exportToCsv({
             filename: `capacity-planning-${new Date().toISOString().split('T')[0]}.csv`,
             data: data.resource_analysis.map(item => ({
-                resourceName: item.resource_name,
-                currentUtilization: formatUtilization(item.current_utilization),
-                forecastUtilization: formatUtilization(item.forecast_utilization),
+                resource_name: item.resource_name,
+                current_utilization: formatUtilization(item.current_utilization),
+                forecast_utilization: formatUtilization(item.forecast_utilization),
                 recommendation: item.recommendation.label,
-                recommendationSeverity: item.recommendation.severity,
-                costImpact: item.cost_impact.label,
-                lastEvaluatedAt: item.last_evaluated_at,
+                recommendation_severity: item.recommendation.severity,
+                cost_impact: item.cost_impact.label,
+                last_evaluated_at: item.last_evaluated_at,
             })),
         });
     };

--- a/pages/automation/AutomationHistoryPage.tsx
+++ b/pages/automation/AutomationHistoryPage.tsx
@@ -120,7 +120,7 @@ const AutomationHistoryPage: React.FC = () => {
 
         exportToCsv({
             filename: `automation-history-${new Date().toISOString().split('T')[0]}.csv`,
-            headers: ['id', 'script_name', 'status', 'trigger_source', 'triggered_by', 'start_time', 'endTime', 'duration_ms'],
+            headers: ['id', 'script_name', 'status', 'trigger_source', 'triggered_by', 'start_time', 'end_time', 'duration_ms'],
             data: dataToExport,
         });
     };

--- a/pages/automation/AutomationPlaybooksPage.tsx
+++ b/pages/automation/AutomationPlaybooksPage.tsx
@@ -179,7 +179,7 @@ const AutomationPlaybooksPage: React.FC = () => {
                         {pb.last_run_status}
                     </span>
                 );
-            case 'lastRunAt':
+            case 'last_run_at':
                 return pb.last_run_at;
             case 'runCount':
                 return pb.run_count;

--- a/pages/automation/AutomationTriggersPage.tsx
+++ b/pages/automation/AutomationTriggersPage.tsx
@@ -190,7 +190,7 @@ const AutomationTriggersPage: React.FC = () => {
         }
     };
 
-    const findPlaybookName = (playbookId: string) => playbookNameMap.get(playbookId) || 'Unknown Playbook';
+    const findPlaybookName = (playbook_id: string) => playbookNameMap.get(playbook_id) || 'Unknown Playbook';
 
     const renderCellContent = (trigger: AutomationTrigger, columnKey: string) => {
         switch (columnKey) {
@@ -212,7 +212,7 @@ const AutomationTriggersPage: React.FC = () => {
                 );
             case 'targetPlaybookId':
                 return findPlaybookName(trigger.target_playbook_id);
-            case 'lastTriggeredAt':
+            case 'last_triggered_at':
                 return trigger.last_triggered_at;
             default:
                 return <span className="text-slate-500">--</span>;

--- a/pages/dashboards/DashboardEditorPage.tsx
+++ b/pages/dashboards/DashboardEditorPage.tsx
@@ -45,7 +45,7 @@ const DashboardEditorPage: React.FC = () => {
     const [interactionState, setInteractionState] = useState<InteractionState>(null);
 
     const [allWidgets, setAllWidgets] = useState<LayoutWidget[]>([]);
-    const [kpiData, setKpiData] = useState<Record<string, any>>({});
+    const [kpi_data, setKpiData] = useState<Record<string, any>>({});
     const [isLoading, setIsLoading] = useState(true);
     const [isSaving, setIsSaving] = useState(false);
     const [error, setError] = useState<string | null>(null);
@@ -327,7 +327,7 @@ const DashboardEditorPage: React.FC = () => {
                             </div>
                         );
                     }
-                    const data = kpiData[widget.id];
+                    const data = kpi_data[widget.id];
                     if (!data) {
                         return (
                             <div key={item.i} className="absolute border border-dashed border-slate-700 bg-slate-900/40 rounded-xl flex flex-col items-center justify-center text-slate-400 text-sm" style={{ top, left, width, height }}>
@@ -342,7 +342,7 @@ const DashboardEditorPage: React.FC = () => {
                             onMouseDown={(e) => handleInteractionStart(e, 'drag', item)}
                             className={`absolute transition-all duration-200 ease-in-out group ${isInteracting ? 'z-20 shadow-2xl opacity-80' : 'z-10'}`}
                             style={{ top, left, width, height }}>
-                            <ContextualKPICard title={widget.name} value={data.value} description={renderDescription(data.description)} icon={data.icon} iconBgColor={data.iconBgColor} />
+                            <ContextualKPICard title={widget.name} value={data.value} description={renderDescription(data.description)} icon={data.icon} icon_bg_color={data.icon_bg_color} />
                             <button onClick={(e) => { e.stopPropagation(); removeWidget(widget.id); }} className="absolute top-2 right-2 p-1 bg-red-600/80 text-white rounded-full opacity-0 group-hover:opacity-100 transition-opacity" title={pageContent.REMOVE_WIDGET_TITLE}><Icon name="x" className="w-4 h-4" /></button>
                             <div onMouseDown={(e) => handleInteractionStart(e, 'resize', item)} className="absolute bottom-0 right-0 w-5 h-5 cursor-se-resize opacity-0 group-hover:opacity-100 transition-opacity">
                                 <Icon name="move-down-right" className="w-4 h-4 text-slate-400 absolute bottom-1 right-1" />

--- a/pages/dashboards/DashboardListPage.tsx
+++ b/pages/dashboards/DashboardListPage.tsx
@@ -206,7 +206,7 @@ const DashboardListPage: React.FC = () => {
 
         exportToCsv({
             filename: `dashboards-${new Date().toISOString().split('T')[0]}.csv`,
-            headers: ['id', 'name', 'type', 'category', 'description', 'owner', 'updatedAt', 'path'],
+            headers: ['id', 'name', 'type', 'category', 'description', 'owner', 'updated_at', 'path'],
             data: dataToExport,
         });
     };

--- a/pages/dashboards/GenericBuiltInDashboardPage.tsx
+++ b/pages/dashboards/GenericBuiltInDashboardPage.tsx
@@ -7,11 +7,11 @@ import { DashboardLayoutItem } from '../../types';
 interface GenericBuiltInDashboardPageProps {
     name: string;
     description: string;
-    widgetIds: DashboardLayoutItem[];
+    widget_ids: DashboardLayoutItem[];
 }
 
-const GenericBuiltInDashboardPage: React.FC<GenericBuiltInDashboardPageProps> = ({ name, description, widgetIds }) => {
-    const ids = widgetIds.map(item => item.i);
+const GenericBuiltInDashboardPage: React.FC<GenericBuiltInDashboardPageProps> = ({ name, description, widget_ids }) => {
+    const ids = widget_ids.map(item => item.i);
     
     return (
         <div className="space-y-6">
@@ -21,8 +21,8 @@ const GenericBuiltInDashboardPage: React.FC<GenericBuiltInDashboardPageProps> = 
                     <p className="text-slate-400 mt-1">{description}</p>
                 </div>
             </div>
-            {/* Pass widgetIds directly to the enhanced PageKPIs component */}
-            <PageKPIs pageName={`dashboard-${name}`} widgetIds={ids} />
+            {/* Pass widget_ids directly to the enhanced PageKPIs component */}
+            <PageKPIs pageName={`dashboard-${name}`} widget_ids={ids} />
         </div>
     );
 };

--- a/pages/incidents/IncidentDetailPage.tsx
+++ b/pages/incidents/IncidentDetailPage.tsx
@@ -12,7 +12,7 @@ import { showToast } from '../../services/toast';
 import Modal from '../../components/Modal';
 
 interface IncidentDetailPageProps {
-  incidentId: string;
+  incident_id: string;
   onUpdate: () => void;
   currentUser: User | null;
 }
@@ -24,7 +24,7 @@ const InfoItem = ({ label, children }: { label: string; children?: React.ReactNo
   </div>
 );
 
-const IncidentDetailPage: React.FC<IncidentDetailPageProps> = ({ incidentId, onUpdate, currentUser }) => {
+const IncidentDetailPage: React.FC<IncidentDetailPageProps> = ({ incident_id, onUpdate, currentUser }) => {
   const [incident, setIncident] = useState<Incident | null>(null);
   const { options } = useOptions();
   const incidentOptions = options?.incidents;
@@ -37,18 +37,18 @@ const IncidentDetailPage: React.FC<IncidentDetailPageProps> = ({ incidentId, onU
   const [isAnalysisLoading, setIsAnalysisLoading] = useState(false);
 
   const fetchIncident = useCallback(async () => {
-    if (!incidentId) return;
+    if (!incident_id) return;
     setIsLoading(true);
     setError(null);
     try {
-      const { data: incidentRes } = await api.get<Incident>(`/incidents/${incidentId}`);
+      const { data: incidentRes } = await api.get<Incident>(`/incidents/${incident_id}`);
       setIncident(incidentRes);
     } catch (err) {
-      setError(`Failed to fetch incident ${incidentId}.`);
+      setError(`Failed to fetch incident ${incident_id}.`);
     } finally {
       setIsLoading(false);
     }
-  }, [incidentId]);
+  }, [incident_id]);
 
   useEffect(() => {
     fetchIncident();
@@ -134,7 +134,7 @@ const IncidentDetailPage: React.FC<IncidentDetailPageProps> = ({ incidentId, onU
       <div className="p-6 text-center text-red-400">
         <Icon name="alert-circle" className="w-12 h-12 mx-auto mb-4" />
         <h2 className="text-2xl font-bold">事故載入失敗</h2>
-        <p>{error || `找不到 ID 為 "${incidentId}" 的事故。`}</p>
+        <p>{error || `找不到 ID 為 "${incident_id}" 的事故。`}</p>
       </div>
     );
   }

--- a/pages/incidents/IncidentListPage.tsx
+++ b/pages/incidents/IncidentListPage.tsx
@@ -55,7 +55,7 @@ const IncidentListPage: React.FC = () => {
     const { options, isLoading: isLoadingOptions } = useOptions();
     const incidentOptions = options?.incidents;
 
-    const { incidentId } = useParams<{ incidentId: string }>();
+    const { incident_id } = useParams<{ incident_id: string }>();
     const navigate = useNavigate();
     const { currentUser } = useUser();
 
@@ -137,7 +137,7 @@ const IncidentListPage: React.FC = () => {
 
         exportToCsv({
             filename: `incidents-${new Date().toISOString().split('T')[0]}.csv`,
-            headers: ['id', 'summary', 'resource', 'status', 'severity', 'impact', 'assignee', 'occurredAt'],
+            headers: ['id', 'summary', 'resource', 'status', 'severity', 'impact', 'assignee', 'occurred_at'],
             data: dataToExport,
         });
     };
@@ -181,7 +181,7 @@ const IncidentListPage: React.FC = () => {
             matchers: [{ key: 'resource', operator: '=', value: incidentToSilence.resource }, { key: 'rule', operator: '=', value: incidentToSilence.rule }],
             schedule: { type: 'single', startsAt: now.toISOString(), endsAt: endsAt.toISOString() },
             creator: currentUser?.name || 'System',
-            createdAt: now.toISOString(),
+            created_at: now.toISOString(),
         };
 
         try {
@@ -372,8 +372,8 @@ const IncidentListPage: React.FC = () => {
                 <Pagination total={totalIncidents} page={currentPage} pageSize={pageSize} onPageChange={setCurrentPage} onPageSizeChange={setPageSize} />
             </TableContainer>
 
-            <Drawer isOpen={!!incidentId} onClose={() => navigate('/incidents')} title={`事故詳情: ${incidentId}`} width="w-3/5">
-                {incidentId && <IncidentDetailPage incidentId={incidentId} onUpdate={fetchIncidents} currentUser={currentUser} />}
+            <Drawer isOpen={!!incident_id} onClose={() => navigate('/incidents')} title={`事故詳情: ${incident_id}`} width="w-3/5">
+                {incident_id && <IncidentDetailPage incident_id={incident_id} onUpdate={fetchIncidents} currentUser={currentUser} />}
             </Drawer>
 
             <UnifiedSearchModal page="incidents" isOpen={isSearchModalOpen} onClose={() => setIsSearchModalOpen(false)} onSearch={(newFilters) => { setFilters(newFilters as IncidentFilters); setIsSearchModalOpen(false); setCurrentPage(1); }} initialFilters={filters} />
@@ -401,7 +401,7 @@ const IncidentListPage: React.FC = () => {
                 onImportSuccess={fetchIncidents}
                 itemName="事件"
                 importEndpoint="/incidents/import"
-                templateHeaders={['id', 'summary', 'resource', 'status', 'severity', 'impact', 'assignee', 'occurredAt']}
+                templateHeaders={['id', 'summary', 'resource', 'status', 'severity', 'impact', 'assignee', 'occurred_at']}
                 templateFilename="incidents-template.csv"
             />
         </div>

--- a/pages/incidents/SilenceRulePage.tsx
+++ b/pages/incidents/SilenceRulePage.tsx
@@ -200,7 +200,7 @@ const SilenceRulePage: React.FC = () => {
         }
         exportToCsv({
             filename: `silence-rules-${new Date().toISOString().split('T')[0]}.csv`,
-            headers: ['id', 'name', 'enabled', 'type', 'creator', 'createdAt'],
+            headers: ['id', 'name', 'enabled', 'type', 'creator', 'created_at'],
             data: rules.map(r => ({ ...r, matchers: JSON.stringify(r.matchers), schedule: JSON.stringify(r.schedule) })),
         });
     };

--- a/pages/resources/AutoDiscoveryPage.tsx
+++ b/pages/resources/AutoDiscoveryPage.tsx
@@ -88,10 +88,10 @@ const AutoDiscoveryPage: React.FC = () => {
         }
     };
 
-    const handleManualRun = async (jobId: string) => {
+    const handleManualRun = async (job_id: string) => {
         showToast('手動執行已觸發...', 'success');
         try {
-            await api.post(`/resources/discovery-jobs/${jobId}/run`);
+            await api.post(`/resources/discovery-jobs/${job_id}/run`);
             fetchJobs(); // Refetch to show running status
         } catch (err) {
             showToast('手動執行失敗。', 'error');

--- a/pages/resources/ResourceListPage.tsx
+++ b/pages/resources/ResourceListPage.tsx
@@ -257,7 +257,7 @@ const ResourceListPage: React.FC = () => {
             case 'provider': return res.provider;
             case 'region': return res.region;
             case 'owner': return res.owner;
-            case 'lastCheckInAt': return formatRelativeTime(res.last_check_in_at);
+            case 'last_check_in_at': return formatRelativeTime(res.last_check_in_at);
             default:
                 return <span className="text-slate-500">--</span>;
         }

--- a/pages/settings/identity-access/PersonnelManagementPage.tsx
+++ b/pages/settings/identity-access/PersonnelManagementPage.tsx
@@ -221,7 +221,7 @@ const PersonnelManagementPage: React.FC = () => {
             case 'role': return user.role;
             case 'team': return user.team;
             case 'status': return <span className={`inline-flex items-center px-2 py-1 text-xs font-semibold rounded-full ${getStatusPill(user.status)}`}>{getStatusLabel(user.status)}</span>;
-            case 'lastLoginAt': return user.last_login_at;
+            case 'last_login_at': return user.last_login_at;
             default:
                 return <span className="text-slate-500">--</span>;
         }

--- a/pages/settings/notification-management/NotificationStrategyPage.tsx
+++ b/pages/settings/notification-management/NotificationStrategyPage.tsx
@@ -240,7 +240,7 @@ const NotificationStrategyPage: React.FC = () => {
             case 'name': return <span className="font-medium text-white">{strategy.name}</span>;
             case 'trigger_condition': return renderConditionTags(strategy.trigger_condition);
             case 'channel_count': return strategy.channel_count;
-            case 'severityLevels':
+            case 'severity_levels':
                 return (
                     <div className="flex flex-wrap gap-1">
                         {strategy.severity_levels.map(level => (
@@ -250,7 +250,7 @@ const NotificationStrategyPage: React.FC = () => {
                         ))}
                     </div>
                 );
-            case 'impactLevels':
+            case 'impact_levels':
                 return (
                     <div className="flex flex-wrap gap-1">
                         {strategy.impact_levels.map(level => (

--- a/pages/settings/platform/LayoutSettingsPage.tsx
+++ b/pages/settings/platform/LayoutSettingsPage.tsx
@@ -91,9 +91,9 @@ const DualListSelector: React.FC<DualListSelectorProps> = ({ available, selected
 };
 
 interface LayoutConfig {
-    widgetIds: string[];
-    updatedAt: string;
-    updatedBy: string;
+    widget_ids: string[];
+    updated_at: string;
+    updated_by: string;
 }
 type LayoutsData = Record<string, LayoutConfig>;
 
@@ -108,7 +108,7 @@ const AccordionItem: React.FC<AccordionItemProps> = ({ pageName, layouts, handle
     const { content } = useContent();
     const pageContent = content?.LAYOUT_SETTINGS;
     const pageLayout = layouts[pageName];
-    const widgetIds = pageLayout?.widgetIds || [];
+    const widget_ids = pageLayout?.widget_ids || [];
     const getWidgetById = (id: string) => allWidgets.find(w => w.id === id);
 
     if (!pageContent) {
@@ -131,9 +131,9 @@ const AccordionItem: React.FC<AccordionItemProps> = ({ pageName, layouts, handle
                     <div className="flex justify-between items-start">
                         <div>
                             <h4 className="font-semibold mb-2">{pageContent.CURRENTLY_DISPLAYED}</h4>
-                            {widgetIds.length > 0 ? (
+                            {widget_ids.length > 0 ? (
                                 <ol className="list-decimal list-inside text-slate-300 space-y-1">
-                                    {widgetIds.map(id => {
+                                    {widget_ids.map(id => {
                                         const widget = getWidgetById(id);
                                         return <li key={id}>{widget?.name || 'Unknown Widget'}</li>;
                                     })}
@@ -194,8 +194,8 @@ const LayoutSettingsPage: React.FC = () => {
 
     const handleEditClick = (pageName: string) => {
         setEditingPage(pageName);
-        const widgetIds = layouts[pageName]?.widgetIds || [];
-        const selected = widgetIds.map(id => getWidgetById(id)).filter(Boolean) as LayoutWidget[];
+        const widget_ids = layouts[pageName]?.widget_ids || [];
+        const selected = widget_ids.map(id => getWidgetById(id)).filter(Boolean) as LayoutWidget[];
         setModalWidgets(selected);
         setIsModalOpen(true);
     };
@@ -203,8 +203,8 @@ const LayoutSettingsPage: React.FC = () => {
     const handleSaveLayout = async () => {
         if (editingPage) {
             const newSelectedIds = modalWidgets.map(w => w.id);
-            const currentLayoutConfig = layouts[editingPage] || { widgetIds: [], updatedAt: '', updatedBy: '' };
-            const updatedLayouts = { ...layouts, [editingPage]: { ...currentLayoutConfig, widgetIds: newSelectedIds } };
+            const currentLayoutConfig = layouts[editingPage] || { widget_ids: [], updated_at: '', updated_by: '' };
+            const updatedLayouts = { ...layouts, [editingPage]: { ...currentLayoutConfig, widget_ids: newSelectedIds } };
 
             try {
                 const { data: savedLayouts } = await api.put<LayoutsData>('/settings/layouts', updatedLayouts);

--- a/pages/settings/platform/TagManagementPage.tsx
+++ b/pages/settings/platform/TagManagementPage.tsx
@@ -295,7 +295,7 @@ const TagManagementPage: React.FC = () => {
                         )}
                     </div>
                 );
-            case 'writableRoles':
+            case 'writable_roles':
                 const roles = tag.writable_roles || [];
                 const maxRolesDisplay = 3;
                 return (

--- a/tag-registry.js
+++ b/tag-registry.js
@@ -22,25 +22,25 @@ const ALL_SCOPES = TAG_SCOPE_OPTIONS.map(option => option.value);
 // ============================================================================
 const CORE_TAGS = [
     // 基礎分類標籤
-    { key: 'env', description: '部署環境。', scopes: ALL_SCOPES, required: true, writableRoles: DEFAULT_WRITABLE_ROLES },
-    { key: 'service', description: '所屬服務名稱。', scopes: ALL_SCOPES, required: false, writableRoles: DEFAULT_WRITABLE_ROLES },
+    { key: 'env', description: '部署環境。', scopes: ALL_SCOPES, required: true, writable_roles: DEFAULT_WRITABLE_ROLES },
+    { key: 'service', description: '所屬服務名稱。', scopes: ALL_SCOPES, required: false, writable_roles: DEFAULT_WRITABLE_ROLES },
     // 事件核心屬性（系統依賴這些標籤）
-    { key: 'status', description: '事件狀態。', scopes: ['incident', 'notification_policy', 'automation'], required: true, writableRoles: DEFAULT_WRITABLE_ROLES },
-    { key: 'severity', description: '事件嚴重度。', scopes: ['incident', 'notification_policy', 'automation'], required: true, writableRoles: DEFAULT_WRITABLE_ROLES },
-    { key: 'impact', description: '事件影響層級。', scopes: ['incident', 'notification_policy', 'automation'], required: true, writableRoles: DEFAULT_WRITABLE_ROLES },
+    { key: 'status', description: '事件狀態。', scopes: ['incident', 'notification_policy', 'automation'], required: true, writable_roles: DEFAULT_WRITABLE_ROLES },
+    { key: 'severity', description: '事件嚴重度。', scopes: ['incident', 'notification_policy', 'automation'], required: true, writable_roles: DEFAULT_WRITABLE_ROLES },
+    { key: 'impact', description: '事件影響層級。', scopes: ['incident', 'notification_policy', 'automation'], required: true, writable_roles: DEFAULT_WRITABLE_ROLES },
 ];
 // ============================================================================
 // 擴展標籤（可選，根據需求使用）
 // ============================================================================
 const EXTENDED_TAGS = [
     // 資源標識
-    { key: 'resource_type', description: '資源種類。', scopes: ['resource', 'incident'], required: false, writableRoles: DEFAULT_WRITABLE_ROLES },
-    { key: 'cluster', description: '叢集名稱。', scopes: ['resource', 'incident'], required: false, writableRoles: DEFAULT_WRITABLE_ROLES },
+    { key: 'resource_type', description: '資源種類。', scopes: ['resource', 'incident'], required: false, writable_roles: DEFAULT_WRITABLE_ROLES },
+    { key: 'cluster', description: '叢集名稱。', scopes: ['resource', 'incident'], required: false, writable_roles: DEFAULT_WRITABLE_ROLES },
     // 監控相關
-    { key: 'datasource_type', description: '資料來源類型。', scopes: ['datasource', 'incident'], required: false, writableRoles: DEFAULT_WRITABLE_ROLES },
+    { key: 'datasource_type', description: '資料來源類型。', scopes: ['datasource', 'incident'], required: false, writable_roles: DEFAULT_WRITABLE_ROLES },
     // 組織相關（自動從關聯實體填充，唯讀）
-    { key: 'team', description: '所屬團隊名稱（自動填充，不可編輯）。', scopes: ['resource', 'incident', 'dashboard', 'alert_rule'], required: false, writableRoles: [], readonly: true, linkToEntity: 'team' },
-    { key: 'owner', description: '負責人姓名（自動填充，不可編輯）。', scopes: ['resource', 'incident', 'dashboard', 'alert_rule'], required: false, writableRoles: [], readonly: true, linkToEntity: 'personnel' },
+    { key: 'team', description: '所屬團隊名稱（自動填充，不可編輯）。', scopes: ['resource', 'incident', 'dashboard', 'alert_rule'], required: false, writable_roles: [], readonly: true, link_to_entity: 'team' },
+    { key: 'owner', description: '負責人姓名（自動填充，不可編輯）。', scopes: ['resource', 'incident', 'dashboard', 'alert_rule'], required: false, writable_roles: [], readonly: true, link_to_entity: 'personnel' },
 ];
 // ============================================================================
 // 標籤註冊表組合
@@ -53,58 +53,58 @@ const registry = [
 // 輔助函數
 // ============================================================================
 const createTagDefinition = (entry) => {
-    // 為系統標籤設置預設的 allowedValues
+    // 為系統標籤設置預設的 allowed_values
     const defaultAllowedValues = {
         'env': [
-            { id: 'env-production', value: 'production', usageCount: 0 },
-            { id: 'env-staging', value: 'staging', usageCount: 0 },
-            { id: 'env-development', value: 'development', usageCount: 0 },
+            { id: 'env-production', value: 'production', usage_count: 0 },
+            { id: 'env-staging', value: 'staging', usage_count: 0 },
+            { id: 'env-development', value: 'development', usage_count: 0 },
         ],
         'service': [
-            { id: 'service-api-gateway', value: 'api-gateway', usageCount: 0 },
-            { id: 'service-user-service', value: 'user-service', usageCount: 0 },
-            { id: 'service-order-service', value: 'order-service', usageCount: 0 },
-            { id: 'service-payment-service', value: 'payment-service', usageCount: 0 },
-            { id: 'service-notification-service', value: 'notification-service', usageCount: 0 },
+            { id: 'service-api-gateway', value: 'api-gateway', usage_count: 0 },
+            { id: 'service-user-service', value: 'user-service', usage_count: 0 },
+            { id: 'service-order-service', value: 'order-service', usage_count: 0 },
+            { id: 'service-payment-service', value: 'payment-service', usage_count: 0 },
+            { id: 'service-notification-service', value: 'notification-service', usage_count: 0 },
         ],
         'status': [
-            { id: 'status-New', value: 'New', usageCount: 0 },
-            { id: 'status-Acknowledged', value: 'Acknowledged', usageCount: 0 },
-            { id: 'status-Resolved', value: 'Resolved', usageCount: 0 },
-            { id: 'status-Silenced', value: 'Silenced', usageCount: 0 },
+            { id: 'status-New', value: 'New', usage_count: 0 },
+            { id: 'status-Acknowledged', value: 'Acknowledged', usage_count: 0 },
+            { id: 'status-Resolved', value: 'Resolved', usage_count: 0 },
+            { id: 'status-Silenced', value: 'Silenced', usage_count: 0 },
         ],
         'severity': [
-            { id: 'severity-Info', value: 'Info', usageCount: 0 },
-            { id: 'severity-Warning', value: 'Warning', usageCount: 0 },
-            { id: 'severity-Critical', value: 'Critical', usageCount: 0 },
+            { id: 'severity-Info', value: 'Info', usage_count: 0 },
+            { id: 'severity-Warning', value: 'Warning', usage_count: 0 },
+            { id: 'severity-Critical', value: 'Critical', usage_count: 0 },
         ],
         'impact': [
-            { id: 'impact-High', value: 'High', usageCount: 0 },
-            { id: 'impact-Medium', value: 'Medium', usageCount: 0 },
-            { id: 'impact-Low', value: 'Low', usageCount: 0 },
+            { id: 'impact-High', value: 'High', usage_count: 0 },
+            { id: 'impact-Medium', value: 'Medium', usage_count: 0 },
+            { id: 'impact-Low', value: 'Low', usage_count: 0 },
         ],
         'cluster': [
-            { id: 'cluster-prod-us-east', value: 'prod-us-east', usageCount: 0 },
-            { id: 'cluster-prod-us-west', value: 'prod-us-west', usageCount: 0 },
-            { id: 'cluster-staging', value: 'staging', usageCount: 0 },
-            { id: 'cluster-dev', value: 'dev', usageCount: 0 },
+            { id: 'cluster-prod-us-east', value: 'prod-us-east', usage_count: 0 },
+            { id: 'cluster-prod-us-west', value: 'prod-us-west', usage_count: 0 },
+            { id: 'cluster-staging', value: 'staging', usage_count: 0 },
+            { id: 'cluster-dev', value: 'dev', usage_count: 0 },
         ],
         'resource_type': [
-            { id: 'resource_type-vm', value: 'vm', usageCount: 0 },
-            { id: 'resource_type-pod', value: 'pod', usageCount: 0 },
-            { id: 'resource_type-service', value: 'service', usageCount: 0 },
-            { id: 'resource_type-device', value: 'device', usageCount: 0 },
+            { id: 'resource_type-vm', value: 'vm', usage_count: 0 },
+            { id: 'resource_type-pod', value: 'pod', usage_count: 0 },
+            { id: 'resource_type-service', value: 'service', usage_count: 0 },
+            { id: 'resource_type-device', value: 'device', usage_count: 0 },
         ],
         'datasource_type': [
-            { id: 'datasource_type-prometheus', value: 'prometheus', usageCount: 0 },
-            { id: 'datasource_type-loki', value: 'loki', usageCount: 0 },
+            { id: 'datasource_type-prometheus', value: 'prometheus', usage_count: 0 },
+            { id: 'datasource_type-loki', value: 'loki', usage_count: 0 },
         ],
     };
     return {
         id: `tag-${entry.key}`,
         ...entry,
-        allowedValues: defaultAllowedValues[entry.key] || [], // 使用預設值或空陣列
-        usageCount: 0,
+        allowed_values: defaultAllowedValues[entry.key] || [], // 使用預設值或空陣列
+        usage_count: 0,
     };
 };
 export const TAG_REGISTRY = registry;

--- a/tag-registry.ts
+++ b/tag-registry.ts
@@ -69,7 +69,7 @@ const registry: TagRegistryEntry[] = [
 // ============================================================================
 
 const createTagDefinition = (entry: TagRegistryEntry): TagDefinition => {
-  // 為系統標籤設置預設的 allowedValues
+  // 為系統標籤設置預設的 allowed_values
   const defaultAllowedValues: Record<string, Array<{ id: string; value: string; usage_count: number }>> = {
     'env': [
       { id: 'env-production', value: 'production', usage_count: 0 },


### PR DESCRIPTION
## Summary
- update KPI, layout, and notification-related components to consume snake_case fields
- align capacity planning charts and CSV export data keys with snake_case naming
- adjust mock server handlers and tag registry helpers to emit snake_case payloads consistently

## Testing
- npx tsc --noEmit
- npm run build *(fails: missing optional rollup native binary in npm environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dd2a511ed0832da3569d40efc9a6c8