### PR TITLE
Add audit logging to tag batch deletes

### DIFF
--- a/mock-server/handlers.ts
+++ b/mock-server/handlers.ts
@@ -2641,10 +2641,18 @@ const handleRequest = async (method: HttpMethod, url: string, params: any, body:
                     }
                     let updated = 0;
                     if (action === 'delete') {
+                        const currentUser = getCurrentUser();
                         DB.tag_definitions.forEach((tag: any) => {
                             if (ids.includes(tag.id)) {
                                 tag.deleted_at = new Date().toISOString();
                                 updated += 1;
+                                auditLogMiddleware(
+                                    currentUser.id,
+                                    'DELETE',
+                                    'TagDefinition',
+                                    tag.id,
+                                    { key: tag.key, scopes: tag.scopes }
+                                );
                             }
                         });
                     } else {


### PR DESCRIPTION
## Summary
- add audit logging for batch tag definition deletions to ensure audit coverage
- record the acting user and tag metadata when deleting tag definitions in bulk

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dd376bf88c832d876f0f8a5ba28e15