### PR TITLE
Align tag registry and docs enums with SSOT

### DIFF
--- a/docs/SYSTEM_TAGS.md
+++ b/docs/SYSTEM_TAGS.md
@@ -3,7 +3,7 @@
 以下清單依據 `tag-registry.ts` 內標記為系統保留（`system: true`）的定義彙整，並依主要情境分類。除非另有說明，所有鍵的命名規範皆遵循 `^[a-z0-9_]{1,32}$`，值長度不超過 128 個字元，布林值限定為 `true | false`，時間以 ISO 8601 格式表示。
 
 ## 通用（Environment & Organization）
-- **env**（字串） — 建議值：`prod`、`staging`、`dev`、`local`
+- **env**（字串） — 建議值：`production`、`staging`、`development`
 - **region**（字串）
 - **zone**（字串）
 - **site**（字串）
@@ -21,7 +21,7 @@
 - **tags.schema_version**（字串，唯一且僅限平台管理員調整）
 
 ## 資源（Resource）
-- **resource_type**（枚舉） — `vm`、`pod`、`service`、`device`、`plc`、`bmc`、`switch`
+- **resource_type**（枚舉） — `vm`、`pod`、`service`、`device`
 - **os**（字串）
 - **distro**（字串）
 - **kernel**（字串）
@@ -36,7 +36,7 @@
 - **edge_gateway**（布林）
 
 ## 資料來源與匯出器（Datasource & Exporter）
-- **datasource_type**（枚舉） — `prometheus`、`victoriametrics`、`loki`、`tempo`、`grafana`
+- **datasource_type**（枚舉） — `victoriametrics`、`grafana`、`elasticsearch`、`prometheus`、`custom`
 - **datasource_id**（字串，需唯一）
 - **exporter_type**（枚舉） — `node`、`snmp`、`modbus`、`ipmi`、`cadvisor`、`kube_state`
 - **protocol**（枚舉） — `snmp`、`modbus`、`opcua`、`ipmi`、`mqtt`
@@ -62,8 +62,8 @@
 - **threshold_profile**（字串）
 - **window**（字串，使用 ISO 8601 duration）
 - **operator**（枚舉） — `>`、`>=`、`<`、`<=`
-- **datasource_type**（枚舉） — `prometheus`、`victoriametrics`、`loki`、`tempo`、`grafana`
-- **resource_type**（枚舉） — `vm`、`pod`、`service`、`device`、`plc`、`bmc`、`switch`
+- **datasource_type**（枚舉） — `victoriametrics`、`grafana`、`elasticsearch`、`prometheus`、`custom`
+- **resource_type**（枚舉） — `vm`、`pod`、`service`、`device`
 - **cluster**（字串）
 - **namespace**（字串）
 - **workload**（字串）
@@ -73,11 +73,11 @@
 - **sla**（字串）
 
 ## 事件（Incident）
-- **status**（枚舉） — `New`、`Acknowledged`、`Resolved`、`Silenced`
-- **severity**（枚舉） — `Info`、`Warning`、`Critical`
-- **impact**（枚舉） — `High`、`Medium`、`Low`
-- **resource_type**（枚舉） — `vm`、`pod`、`service`、`device`、`plc`、`bmc`、`switch`
-- **datasource_type**（枚舉） — `prometheus`、`victoriametrics`、`loki`、`tempo`、`grafana`
+- **status**（枚舉） — `new`、`acknowledged`、`resolved`、`silenced`
+- **severity**（枚舉） — `critical`、`warning`、`info`
+- **impact**（枚舉） — `high`、`medium`、`low`
+- **resource_type**（枚舉） — `vm`、`pod`、`service`、`device`
+- **datasource_type**（枚舉） — `victoriametrics`、`grafana`、`elasticsearch`、`prometheus`、`custom`
 - **cluster**（字串）
 - **namespace**（字串）
 - **workload**（字串）
@@ -95,23 +95,23 @@
 - **maintenance_window**（字串）
 
 ## 通知（Notification Policy）
-- **channel**（枚舉） — `email`、`slack`、`pagerduty`、`webhook`
+- **channel**（枚舉） — `email`、`webhook`、`slack`、`line`、`sms`
 - **routing_key**（字串，需唯一）
 - **oncall_team**（字串）
-- **status**（枚舉） — `New`、`Acknowledged`、`Resolved`、`Silenced`
-- **severity**（枚舉） — `Info`、`Warning`、`Critical`
-- **impact**（枚舉） — `High`、`Medium`、`Low`
+- **status**（枚舉） — `new`、`acknowledged`、`resolved`、`silenced`
+- **severity**（枚舉） — `critical`、`warning`、`info`
+- **impact**（枚舉） — `high`、`medium`、`low`
 - **service**（字串）
 - **team**（字串）
 - **sla**（字串）
 
 ## 自動化（Automation）
+- **playbook_type**（枚舉） — `shell`、`python`、`ansible`、`terraform`
 - **playbook_id**（字串）
-- **playbook_type**（枚舉） — `shell`、`python`、`ansible`、`n8n`
 - **safe_mode**（布林）
-- **status**（枚舉） — `New`、`Acknowledged`、`Resolved`、`Silenced`
-- **severity**（枚舉） — `Info`、`Warning`、`Critical`
-- **impact**（枚舉） — `High`、`Medium`、`Low`
+- **status**（枚舉） — `new`、`acknowledged`、`resolved`、`silenced`
+- **severity**（枚舉） — `critical`、`warning`、`info`
+- **impact**（枚舉） — `high`、`medium`、`low`
 - **resource_id**（字串）
 - **service**（字串）
 - **component**（字串）

--- a/pages/incidents/IncidentDetailPage.tsx
+++ b/pages/incidents/IncidentDetailPage.tsx
@@ -188,7 +188,7 @@ const IncidentDetailPage: React.FC<IncidentDetailPageProps> = ({ incident_id, on
               <span className="text-slate-200">{incident.occurred_at}</span>
             </InfoItem>
             <InfoItem label="指派給">
-              {incident.status === 'New' || !incident.assignee ? (
+              {incident.status === 'new' || !incident.assignee ? (
                 <div className="flex items-center flex-wrap gap-2">
                   <span className="text-slate-400">無</span>
                   <button onClick={handleAcknowledge} className="px-3 py-1.5 text-xs font-semibold text-white bg-sky-600 hover:bg-sky-700 rounded-full transition-colors flex items-center shadow-sm">

--- a/pages/resources/ResourceDetailPage.tsx
+++ b/pages/resources/ResourceDetailPage.tsx
@@ -145,7 +145,7 @@ const ResourceDetailPage: React.FC<ResourceDetailPageProps> = ({ resource_id }) 
                     <p className="font-semibold text-white">{inc.summary}</p>
                     <p className="text-xs text-slate-400">{inc.occurred_at}</p>
                   </div>
-                  <span className={`px-2 py-1 text-xs font-semibold rounded-full capitalize ${inc.status === 'New' ? 'text-orange-400' : 'text-slate-400'}`}>{inc.status}</span>
+                  <span className={`px-2 py-1 text-xs font-semibold rounded-full capitalize ${inc.status === 'new' ? 'text-orange-400' : 'text-slate-400'}`}>{inc.status}</span>
                 </div>
               </Link>
             ))

--- a/tag-registry.js
+++ b/tag-registry.js
@@ -70,20 +70,18 @@ const createTagDefinition = (entry) => {
         'status': [
             { id: 'status-new', value: 'new', usage_count: 0 },
             { id: 'status-acknowledged', value: 'acknowledged', usage_count: 0 },
-            { id: 'status-investigating', value: 'investigating', usage_count: 0 },
             { id: 'status-resolved', value: 'resolved', usage_count: 0 },
-            { id: 'status-closed', value: 'closed', usage_count: 0 },
             { id: 'status-silenced', value: 'silenced', usage_count: 0 },
         ],
         'severity': [
-            { id: 'severity-Info', value: 'Info', usage_count: 0 },
-            { id: 'severity-Warning', value: 'Warning', usage_count: 0 },
-            { id: 'severity-Critical', value: 'Critical', usage_count: 0 },
+            { id: 'severity-critical', value: 'critical', usage_count: 0 },
+            { id: 'severity-warning', value: 'warning', usage_count: 0 },
+            { id: 'severity-info', value: 'info', usage_count: 0 },
         ],
         'impact': [
-            { id: 'impact-High', value: 'High', usage_count: 0 },
-            { id: 'impact-Medium', value: 'Medium', usage_count: 0 },
-            { id: 'impact-Low', value: 'Low', usage_count: 0 },
+            { id: 'impact-high', value: 'high', usage_count: 0 },
+            { id: 'impact-medium', value: 'medium', usage_count: 0 },
+            { id: 'impact-low', value: 'low', usage_count: 0 },
         ],
         'cluster': [
             { id: 'cluster-prod-us-east', value: 'prod-us-east', usage_count: 0 },
@@ -98,8 +96,11 @@ const createTagDefinition = (entry) => {
             { id: 'resource_type-device', value: 'device', usage_count: 0 },
         ],
         'datasource_type': [
+            { id: 'datasource_type-victoriametrics', value: 'victoriametrics', usage_count: 0 },
+            { id: 'datasource_type-grafana', value: 'grafana', usage_count: 0 },
+            { id: 'datasource_type-elasticsearch', value: 'elasticsearch', usage_count: 0 },
             { id: 'datasource_type-prometheus', value: 'prometheus', usage_count: 0 },
-            { id: 'datasource_type-loki', value: 'loki', usage_count: 0 },
+            { id: 'datasource_type-custom', value: 'custom', usage_count: 0 },
         ],
     };
     return {
@@ -115,14 +116,14 @@ export const getTagRegistryEntry = (key) => registry.find(entry => entry.key ===
 export const getEnumValuesForTag = (key) => {
     // 為系統標籤提供預設值
     const defaultValues = {
-        'status': ['new', 'acknowledged', 'investigating', 'resolved', 'closed', 'silenced'],
-        'severity': ['Info', 'Warning', 'Critical'],
-        'impact': ['High', 'Medium', 'Low'],
+        'status': ['new', 'acknowledged', 'resolved', 'silenced'],
+        'severity': ['critical', 'warning', 'info'],
+        'impact': ['high', 'medium', 'low'],
         'env': ['production', 'staging', 'development'],
         'service': ['api-gateway', 'user-service', 'order-service', 'payment-service', 'notification-service'],
         'cluster': ['prod-us-east', 'prod-us-west', 'staging', 'dev'],
         'resource_type': ['vm', 'pod', 'service', 'device'],
-        'datasource_type': ['prometheus', 'loki'],
+        'datasource_type': ['victoriametrics', 'grafana', 'elasticsearch', 'prometheus', 'custom'],
     };
     return defaultValues[key] ?? [];
 };

--- a/tag-registry.ts
+++ b/tag-registry.ts
@@ -86,20 +86,18 @@ const createTagDefinition = (entry: TagRegistryEntry): TagDefinition => {
     'status': [
       { id: 'status-new', value: 'new', usage_count: 0 },
       { id: 'status-acknowledged', value: 'acknowledged', usage_count: 0 },
-      { id: 'status-investigating', value: 'investigating', usage_count: 0 },
       { id: 'status-resolved', value: 'resolved', usage_count: 0 },
-      { id: 'status-closed', value: 'closed', usage_count: 0 },
       { id: 'status-silenced', value: 'silenced', usage_count: 0 },
     ],
     'severity': [
-      { id: 'severity-Info', value: 'Info', usage_count: 0 },
-      { id: 'severity-Warning', value: 'Warning', usage_count: 0 },
-      { id: 'severity-Critical', value: 'Critical', usage_count: 0 },
+      { id: 'severity-critical', value: 'critical', usage_count: 0 },
+      { id: 'severity-warning', value: 'warning', usage_count: 0 },
+      { id: 'severity-info', value: 'info', usage_count: 0 },
     ],
     'impact': [
-      { id: 'impact-High', value: 'High', usage_count: 0 },
-      { id: 'impact-Medium', value: 'Medium', usage_count: 0 },
-      { id: 'impact-Low', value: 'Low', usage_count: 0 },
+      { id: 'impact-high', value: 'high', usage_count: 0 },
+      { id: 'impact-medium', value: 'medium', usage_count: 0 },
+      { id: 'impact-low', value: 'low', usage_count: 0 },
     ],
     'cluster': [
       { id: 'cluster-prod-us-east', value: 'prod-us-east', usage_count: 0 },
@@ -114,8 +112,11 @@ const createTagDefinition = (entry: TagRegistryEntry): TagDefinition => {
       { id: 'resource_type-device', value: 'device', usage_count: 0 },
     ],
     'datasource_type': [
+      { id: 'datasource_type-victoriametrics', value: 'victoriametrics', usage_count: 0 },
+      { id: 'datasource_type-grafana', value: 'grafana', usage_count: 0 },
+      { id: 'datasource_type-elasticsearch', value: 'elasticsearch', usage_count: 0 },
       { id: 'datasource_type-prometheus', value: 'prometheus', usage_count: 0 },
-      { id: 'datasource_type-loki', value: 'loki', usage_count: 0 },
+      { id: 'datasource_type-custom', value: 'custom', usage_count: 0 },
     ],
   };
 
@@ -136,14 +137,14 @@ export const getTagRegistryEntry = (key: string): TagRegistryEntry | undefined =
 export const getEnumValuesForTag = (key: string): string[] => {
   // 為系統標籤提供預設值
   const defaultValues: Record<string, string[]> = {
-    'status': ['new', 'acknowledged', 'investigating', 'resolved', 'closed', 'silenced'],
-    'severity': ['Info', 'Warning', 'Critical'],
-    'impact': ['High', 'Medium', 'Low'],
+    'status': ['new', 'acknowledged', 'resolved', 'silenced'],
+    'severity': ['critical', 'warning', 'info'],
+    'impact': ['high', 'medium', 'low'],
     'env': ['production', 'staging', 'development'],
     'service': ['api-gateway', 'user-service', 'order-service', 'payment-service', 'notification-service'],
     'cluster': ['prod-us-east', 'prod-us-west', 'staging', 'dev'],
     'resource_type': ['vm', 'pod', 'service', 'device'],
-    'datasource_type': ['prometheus', 'loki'],
+    'datasource_type': ['victoriametrics', 'grafana', 'elasticsearch', 'prometheus', 'custom'],
   };
   return defaultValues[key] ?? [];
 };


### PR DESCRIPTION
## Summary
- align the tag registry defaults with the lowercase SSOT enums for statuses, severities, impacts, and datasource types
- refresh the system tag documentation to reference the SSOT enum values
- update incident-related UI checks to compare against the lowercase incident status literals

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ddf9e81264832d9d20904a227bf0e4