### PR TITLE
Align enum usage across mock server and OpenAPI

### DIFF
--- a/mock-server/db.ts
+++ b/mock-server/db.ts
@@ -1544,7 +1544,7 @@ const MOCK_NOTIFICATION_STRATEGIES: NotificationStrategy[] = [
         id: 'strat-1',
         name: 'Critical Database Alerts',
         enabled: true,
-        trigger_condition: 'severity = Critical AND service = api-gateway',
+        trigger_condition: 'severity = critical AND service = api-gateway',
         channel_count: 2,
         severity_levels: ['critical'],
         impact_levels: ['high'],
@@ -1556,7 +1556,7 @@ const MOCK_NOTIFICATION_STRATEGIES: NotificationStrategy[] = [
 const MOCK_NOTIFICATION_STRATEGY_OPTIONS: NotificationStrategyOptions = {
     severity_levels: ['critical', 'warning', 'info'],
     impact_levels: ['high', 'medium', 'low'],
-    default_condition: 'severity = Critical',
+    default_condition: 'severity = critical',
     condition_keys: {
         severity: ['critical', 'warning', 'info'],
         impact: ['high', 'medium', 'low'],

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1644,7 +1644,7 @@ components:
           type: string
         status:
           type: string
-          enum: [active, inactive]
+          enum: [active, invited, inactive]
         avatar:
           type: string
         last_login_at:
@@ -1743,6 +1743,7 @@ components:
           type: object
         last_test_result:
           type: string
+          enum: [success, failed, not_tested]
         last_tested_at:
           type: string
           format: date-time
@@ -1783,10 +1784,12 @@ components:
           type: array
           items:
             type: string
+            enum: [critical, warning, info]
         impact_levels:
           type: array
           items:
             type: string
+            enum: [high, medium, low]
         channel_ids:
           type: array
           items:
@@ -1812,6 +1815,7 @@ components:
           type: array
           items:
             type: string
+            enum: [critical, warning, info]
         channel_ids:
           type: array
           items:


### PR DESCRIPTION
## Summary
- align the OpenAPI user status and notification-related enums with the SSOT definitions
- normalize mock notification strategy conditions to use lowercase severity codes

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68de3508b90c832d91d894d761d8498e