### PR TITLE
Align enums with SSOT across mock server and OpenAPI specs

### DIFF
--- a/mock-server/handlers.ts
+++ b/mock-server/handlers.ts
@@ -835,9 +835,9 @@ const handleRequest = async (method: HttpMethod, url: string, params: any, body:
                         timestamp,
                         strategy: 'Manual Notification',
                         channel: 'System',
-                        channel_type: 'System' as NotificationChannelType,
+                        channel_type: 'email' as NotificationChannelType,
                         recipient: 'Admin',
-                        status: 'success' as const,
+                        status: 'sent' as const,
                         content: `手動觸發通知: ${incident.summary}`
                     };
 
@@ -847,7 +847,7 @@ const handleRequest = async (method: HttpMethod, url: string, params: any, body:
                     const currentUser = getCurrentUser();
                     auditLogMiddleware(
                         currentUser.id,
-                        'NOTIFY',
+                        'execute',
                         'Incident',
                         id,
                         { summary: incident.summary }

--- a/openapi-specs/02-common-responses.yaml
+++ b/openapi-specs/02-common-responses.yaml
@@ -19,7 +19,7 @@ components:
             invalidEnum:
               summary: Invalid enum value
               value:
-                error: "Invalid status. Allowed values: new, acknowledged, investigating, resolved, closed, silenced"
+                error: "Invalid status. Allowed values: new, acknowledged, resolved, silenced"
 
     NotFound:
       description: Resource Not Found

--- a/openapi-specs/03-schemas-core.yaml
+++ b/openapi-specs/03-schemas-core.yaml
@@ -137,7 +137,7 @@ components:
           example: rule-002
         status:
           type: string
-          enum: [new, acknowledged, investigating, resolved, closed, silenced]
+          enum: [new, acknowledged, resolved, silenced]
           description: 事件目前的生命週期狀態；`silenced` 代表事件已被靜音且暫停通知。
           example: new
         severity:
@@ -244,7 +244,7 @@ components:
       properties:
         status:
           type: string
-          enum: [new, acknowledged, investigating, resolved, closed, silenced]
+          enum: [new, acknowledged, resolved, silenced]
           description: 更新事件狀態；`silenced` 可用於暫時停用通知。
         assignee:
           type: string

--- a/openapi-specs/05-schemas-iam.yaml
+++ b/openapi-specs/05-schemas-iam.yaml
@@ -27,7 +27,7 @@ components:
           example: SRE 平台團隊
         status:
           type: string
-          enum: [active, inactive]
+          enum: [active, invited, inactive]
           example: active
         avatar:
           type: string
@@ -80,7 +80,7 @@ components:
           type: string
         status:
           type: string
-          enum: [active, inactive]
+          enum: [active, invited, inactive]
 
     # ===================
     # Team

--- a/openapi-specs/07-schemas-analysis.yaml
+++ b/openapi-specs/07-schemas-analysis.yaml
@@ -54,7 +54,7 @@ components:
           example: web-server-01
         risk_level:
           type: string
-          enum: [low, medium, high, critical]
+          enum: [high, medium, low]
           example: medium
         risk_analysis:
           type: string
@@ -67,20 +67,15 @@ components:
               type:
                 type: string
                 enum: [cost, performance, security]
-              priority:
-                type: string
-                enum: [low, medium, high, critical]
               suggestion:
                 type: string
               estimated_impact:
                 type: string
           example:
             - type: performance
-              priority: high
               suggestion: "建議增加 CPU 核心數從 2 核升級到 4 核"
               estimated_impact: "預計可降低 CPU 使用率 40%"
             - type: cost
-              priority: medium
               suggestion: "考慮使用保留實例降低成本"
               estimated_impact: "預計可節省 30% 運算成本"
         predicted_issues:

--- a/openapi-specs/09-paths-incidents.yaml
+++ b/openapi-specs/09-paths-incidents.yaml
@@ -16,7 +16,7 @@ paths:
           description: Filter by incident status
           schema:
             type: string
-            enum: [new, acknowledged, investigating, resolved, closed, silenced]
+            enum: [new, acknowledged, resolved, silenced]
           example: acknowledged
         - name: severity
           in: query


### PR DESCRIPTION
## Summary
- update mock server manual notification handling to emit SSOT-compliant notification channel, status, and audit action values
- sync OpenAPI incident, IAM, and analysis schemas plus shared responses with the SSOT enum definitions

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68de45e0dad0832dad9190c53a0aae68