### PR TITLE
feat: enrich backtesting replay analysis

### DIFF
--- a/db_schema.sql
+++ b/db_schema.sql
@@ -635,6 +635,26 @@ CREATE INDEX idx_log_analyses_time_range ON log_analyses(time_range_start, time_
 CREATE INDEX idx_log_analyses_analysis_time ON log_analyses(analysis_time);
 
 -- Backtesting Tasks Table
+-- Ground Truth Events Table (Manual annotations)
+CREATE TABLE ground_truth_events (
+    id VARCHAR(255) PRIMARY KEY,
+    resource_id VARCHAR(255) REFERENCES resources(id),
+    rule_id VARCHAR(255) REFERENCES alert_rules(id),
+    event_timestamp TIMESTAMPTZ NOT NULL,
+    end_timestamp TIMESTAMPTZ,
+    tags TEXT[] DEFAULT '{}',
+    severity incident_severity,
+    description TEXT,
+    created_by VARCHAR(255) REFERENCES users(id),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    deleted_at TIMESTAMPTZ
+);
+
+CREATE INDEX idx_ground_truth_events_timestamp ON ground_truth_events(event_timestamp);
+CREATE INDEX idx_ground_truth_events_rule_id ON ground_truth_events(rule_id);
+CREATE INDEX idx_ground_truth_events_resource_id ON ground_truth_events(resource_id);
+
 CREATE TABLE backtesting_tasks (
     id VARCHAR(255) PRIMARY KEY,
     rule_ids TEXT[] NOT NULL,
@@ -879,6 +899,7 @@ CREATE TRIGGER update_automation_triggers_updated_at BEFORE UPDATE ON automation
 CREATE TRIGGER update_notification_channels_updated_at BEFORE UPDATE ON notification_channels FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
 CREATE TRIGGER update_notification_strategies_updated_at BEFORE UPDATE ON notification_strategies FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
 CREATE TRIGGER update_dashboards_updated_at BEFORE UPDATE ON dashboards FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+CREATE TRIGGER update_ground_truth_events_updated_at BEFORE UPDATE ON ground_truth_events FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
 CREATE TRIGGER update_backtesting_tasks_updated_at BEFORE UPDATE ON backtesting_tasks FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
 CREATE TRIGGER update_backtesting_results_updated_at BEFORE UPDATE ON backtesting_results FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
 CREATE TRIGGER update_tag_definitions_updated_at BEFORE UPDATE ON tag_definitions FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
@@ -912,6 +933,7 @@ COMMENT ON TABLE incident_analyses IS 'AI-powered incident analysis results';
 COMMENT ON TABLE resource_analyses IS 'AI-powered resource analysis and optimization suggestions';
 COMMENT ON TABLE multi_incident_analyses IS 'Correlation analysis across multiple incidents';
 COMMENT ON TABLE log_analyses IS 'Log pattern analysis and anomaly detection';
+COMMENT ON TABLE ground_truth_events IS 'Human annotated incidents used as ground truth for replay validation';
 COMMENT ON TABLE backtesting_tasks IS 'Historical replay tasks for validating alert rules against past data';
 COMMENT ON TABLE backtesting_results IS 'Per-rule backtesting outcomes, trigger timeline, and tuning metrics';
 COMMENT ON TABLE audit_logs IS 'Audit trail for all system operations';

--- a/openapi-specs/07-schemas-analysis.yaml
+++ b/openapi-specs/07-schemas-analysis.yaml
@@ -579,6 +579,11 @@ components:
       type: string
       enum: [queued, pending, running, completed, failed]
 
+    BacktestingMatchStatus:
+      type: string
+      description: Comparison outcome between replay trigger and ground truth annotation.
+      enum: [true_positive, false_positive, false_negative, unknown]
+
     BacktestingTimeRange:
       type: object
       required: [start_time, end_time]
@@ -612,6 +617,27 @@ components:
         notes:
           type: string
           description: Additional context for the event comparison.
+        tags:
+          type: array
+          description: Labeled attributes of the incident for downstream correlation.
+          items:
+            type: string
+        match_status:
+          $ref: '#/components/schemas/BacktestingMatchStatus'
+        matched_trigger_point_id:
+          type: string
+          nullable: true
+          description: Identifier of the detected trigger that matched this ground truth event.
+        detection_time:
+          type: string
+          format: date-time
+          nullable: true
+          description: Timestamp when the rule detected the event, if any.
+        detection_delay_seconds:
+          type: number
+          format: float
+          nullable: true
+          description: Time difference in seconds between the annotated start and detection time.
 
     BacktestingTaskOptions:
       type: object
@@ -698,7 +724,29 @@ components:
         duration_minutes:
           type: integer
           minimum: 0
+        match_status:
+          $ref: '#/components/schemas/BacktestingMatchStatus'
+        ground_truth_event_id:
+          type: string
           nullable: true
+          description: Matched ground truth event identifier.
+        ground_truth_event_label:
+          type: string
+          nullable: true
+          description: Display name of the matched ground truth event.
+        tags:
+          type: array
+          items:
+            type: string
+          description: Tags carried over from the triggering datapoints or alert metadata.
+        notes:
+          type: string
+          description: Additional diagnostic notes for this trigger.
+        detection_delay_seconds:
+          type: number
+          format: float
+          nullable: true
+          description: Detection delay (seconds) relative to the annotated event.
 
     BacktestingRecommendation:
       type: object

--- a/pages/analysis/BacktestingPage.tsx
+++ b/pages/analysis/BacktestingPage.tsx
@@ -6,6 +6,7 @@ import api from '../../services/api';
 import { showToast } from '../../services/toast';
 import {
     AlertRule,
+    BacktestingMatchStatus,
     BacktestingResultsResponse,
     BacktestingRuleResult,
     BacktestingRunRequest,
@@ -36,7 +37,6 @@ const formatDisplayTime = (value: string) => {
 };
 
 const BacktestingPage: React.FC = () => {
-    const now = useMemo(() => new Date(), []);
     const defaultStart = useMemo(() => {
         const date = new Date();
         date.setDate(date.getDate() - 7);
@@ -49,7 +49,8 @@ const BacktestingPage: React.FC = () => {
     const [activeRuleId, setActiveRuleId] = useState<string | null>(null);
 
     const [startInput, setStartInput] = useState<string>(toInputValue(defaultStart));
-    const [endInput, setEndInput] = useState<string>(toInputValue(now));
+    const [endInput, setEndInput] = useState<string>(toInputValue(new Date()));
+    const [quickRange, setQuickRange] = useState<'1h' | '24h' | '7d' | 'custom'>('7d');
 
     const [includeRecommendations, setIncludeRecommendations] = useState(true);
 
@@ -126,6 +127,24 @@ const BacktestingPage: React.FC = () => {
         pollingRef.current = window.setInterval(() => pollResults(id), 5000);
     }, [pollResults]);
 
+    const applyQuickRange = useCallback((range: '1h' | '24h' | '7d' | 'custom') => {
+        setQuickRange(range);
+        if (range === 'custom') {
+            return;
+        }
+        const end = new Date();
+        const start = new Date(end.getTime());
+        if (range === '1h') {
+            start.setHours(end.getHours() - 1);
+        } else if (range === '24h') {
+            start.setDate(end.getDate() - 1);
+        } else if (range === '7d') {
+            start.setDate(end.getDate() - 7);
+        }
+        setStartInput(toInputValue(start));
+        setEndInput(toInputValue(end));
+    }, []);
+
     const handleRunBacktesting = async () => {
         if (selectedRuleIds.length === 0) {
             showToast('請至少選擇一條告警規則。', 'warning');
@@ -133,6 +152,10 @@ const BacktestingPage: React.FC = () => {
         }
         if (!startInput || !endInput) {
             showToast('請選擇完整的模擬時間範圍。', 'warning');
+            return;
+        }
+        if (new Date(startInput) >= new Date(endInput)) {
+            showToast('開始時間需早於結束時間。', 'warning');
             return;
         }
 
@@ -198,16 +221,100 @@ const BacktestingPage: React.FC = () => {
         const metricValues = activeRule.metric_series.map(point => point.value);
         const thresholdValues = activeRule.metric_series.map(point => point.threshold ?? null);
         const baselineValues = activeRule.metric_series.map(point => point.baseline ?? null);
-        const triggerPoints = activeRule.trigger_points.map(point => [formatDisplayTime(point.timestamp), point.value]);
-        const markAreas = [];
+
+        const statusColorMap: Record<BacktestingMatchStatus, string> = {
+            true_positive: '#34d399',
+            false_positive: '#f87171',
+            false_negative: '#fbbf24',
+            unknown: '#94a3b8',
+        };
+
+        const triggerPoints = activeRule.trigger_points.map(point => {
+            const matchStatus: BacktestingMatchStatus = point.match_status || 'unknown';
+            const displayTimestamp = formatDisplayTime(point.timestamp);
+            return {
+                value: [displayTimestamp, point.value],
+                condition_summary: point.condition_summary,
+                match_status: matchStatus,
+                ground_truth_event_label: point.ground_truth_event_label,
+                detection_delay_seconds: point.detection_delay_seconds,
+                itemStyle: {
+                    color: statusColorMap[matchStatus],
+                    borderColor: '#0f172a',
+                    borderWidth: 1,
+                },
+            };
+        });
+
+        const markAreas = activeRule.actual_events.map(event => {
+            const matchStatus: BacktestingMatchStatus = event.match_status || 'unknown';
+            const start = formatDisplayTime(event.start_time);
+            const end = formatDisplayTime(event.end_time ?? event.start_time);
+            return [
+                {
+                    name: event.label,
+                    xAxis: start,
+                    itemStyle: {
+                        color: `${statusColorMap[matchStatus]}33`,
+                    },
+                },
+                {
+                    xAxis: end,
+                },
+            ];
+        });
+
+        const tooltipFormatter = (params: any) => {
+            if (!Array.isArray(params)) {
+                return '';
+            }
+            const axisValue = params[0]?.axisValueLabel ?? '';
+            const rows = [`<div class="font-medium">${axisValue}</div>`];
+            params.forEach((item: any) => {
+                if (!item || !item.seriesName) {
+                    return;
+                }
+                if (item.seriesName === '觸發點') {
+                    const matchStatus: BacktestingMatchStatus = item.data?.match_status || 'unknown';
+                    const statusLabel = matchStatus === 'true_positive'
+                        ? '命中'
+                        : matchStatus === 'false_positive'
+                            ? '誤報'
+                            : matchStatus === 'false_negative'
+                                ? '漏報'
+                                : '無對照';
+                    const delay = item.data?.detection_delay_seconds;
+                    const groundTruthLabel = item.data?.ground_truth_event_label;
+                    rows.push(
+                        `<div>${item.marker} ${item.seriesName} — 值 ${item.data?.value?.[1]} (${statusLabel})</div>`
+                    );
+                    if (groundTruthLabel) {
+                        rows.push(`<div class="text-xs">對應事件：${groundTruthLabel}</div>`);
+                    }
+                    if (typeof delay === 'number') {
+                        rows.push(`<div class="text-xs">偵測延遲：${delay} 秒</div>`);
+                    }
+                } else {
+                    rows.push(`<div>${item.marker} ${item.seriesName}: ${item.data}</div>`);
+                }
+            });
+            return rows.join('');
+        };
 
         return {
-            tooltip: { trigger: 'axis' },
+            tooltip: {
+                trigger: 'axis',
+                axisPointer: { type: 'cross' },
+                backgroundColor: 'rgba(15,23,42,0.9)',
+                borderColor: '#1e293b',
+                textStyle: { color: '#e2e8f0', fontSize: 12 },
+                formatter: tooltipFormatter,
+            },
             legend: {
                 data: ['指標值', '門檻值', '基準值', '觸發點'],
                 textStyle: { color: '#cbd5f5' },
             },
-            grid: { left: '3%', right: '4%', bottom: '8%', containLabel: true },
+            grid: { left: '3%', right: '4%', bottom: '14%', containLabel: true },
             xAxis: {
                 type: 'category',
                 data: timestamps,
@@ -218,6 +325,28 @@ const BacktestingPage: React.FC = () => {
                 axisLine: { lineStyle: { color: '#475569' } },
                 splitLine: { lineStyle: { color: '#1f2937' } },
             },
+            dataZoom: [
+                {
+                    type: 'inside',
+                    throttle: 50,
+                    zoomOnMouseWheel: true,
+                },
+                {
+                    type: 'slider',
+                    bottom: 0,
+                    height: 18,
+                    brushSelect: true,
+                    handleIcon:
+                        'path://M512 0a64 64 0 0 1 64 64v896a64 64 0 0 1-128 0V64A64 64 0 0 1 512 0z',
+                    textStyle: { color: '#cbd5f5' },
+                    borderColor: '#334155',
+                    backgroundColor: '#0f172a',
+                    fillerColor: 'rgba(56,189,248,0.15)',
+                    handleStyle: {
+                        color: '#38bdf8',
+                    },
+                },
+            ],
             series: [
                 {
                     name: '指標值',
@@ -225,27 +354,30 @@ const BacktestingPage: React.FC = () => {
                     smooth: true,
                     symbol: 'none',
                     data: metricValues,
+                    lineStyle: { width: 2 },
                 },
                 {
                     name: '門檻值',
                     type: 'line',
                     symbol: 'none',
                     data: thresholdValues,
-                    lineStyle: { type: 'dashed' },
+                    lineStyle: { type: 'dashed', width: 1 },
                 },
                 {
                     name: '基準值',
                     type: 'line',
                     symbol: 'none',
                     data: baselineValues,
-                    lineStyle: { type: 'dotted' },
+                    lineStyle: { type: 'dotted', width: 1 },
                 },
                 {
                     name: '觸發點',
                     type: 'scatter',
                     data: triggerPoints,
                     symbolSize: 12,
-                    itemStyle: { color: '#f87171' },
+                    emphasis: {
+                        scale: 1.2,
+                    },
                 },
             ],
             ...(markAreas.length > 0 ? {
@@ -253,11 +385,44 @@ const BacktestingPage: React.FC = () => {
                     data: markAreas,
                     label: {
                         color: '#cbd5f5',
+                        fontSize: 10,
+                    },
+                    itemStyle: {
+                        opacity: 0.2,
                     },
                 }
             } : {}),
         };
     }, [activeRule]);
+
+    const matchStatusConfig: Record<BacktestingMatchStatus, { label: string; className: string }> = {
+        true_positive: {
+            label: '命中',
+            className: 'bg-emerald-400/10 border border-emerald-400/30 text-emerald-200',
+        },
+        false_positive: {
+            label: '誤報',
+            className: 'bg-rose-400/10 border border-rose-400/30 text-rose-200',
+        },
+        false_negative: {
+            label: '漏報',
+            className: 'bg-amber-400/10 border border-amber-400/30 text-amber-200',
+        },
+        unknown: {
+            label: '無對照',
+            className: 'bg-slate-500/10 border border-slate-500/30 text-slate-200',
+        },
+    };
+
+    const renderMatchBadge = (status?: BacktestingMatchStatus) => {
+        const key = status || 'unknown';
+        const config = matchStatusConfig[key] ?? matchStatusConfig.unknown;
+        return (
+            <span className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${config.className}`}>
+                {config.label}
+            </span>
+        );
+    };
 
     const renderStatus = () => {
         if (!taskId) {
@@ -337,24 +502,55 @@ const BacktestingPage: React.FC = () => {
                         </select>
                     </div>
 
-                    <div className="grid grid-cols-1 gap-4">
-                        <div>
-                            <label className="text-sm font-medium text-slate-300">開始時間</label>
-                            <input
-                                type="datetime-local"
-                                value={startInput}
-                                onChange={event => setStartInput(event.target.value)}
-                                className="mt-1 w-full rounded-md bg-slate-900 border border-slate-700 px-3 py-2 text-sm text-slate-100"
-                            />
+                    <div className="space-y-3">
+                        <div className="flex flex-wrap items-center gap-2 text-xs text-slate-400">
+                            <span className="font-medium text-slate-300">快速區間</span>
+                            {[
+                                { label: '最近 1 小時', value: '1h' as const },
+                                { label: '最近 24 小時', value: '24h' as const },
+                                { label: '最近 7 天', value: '7d' as const },
+                                { label: '自訂', value: 'custom' as const },
+                            ].map(option => (
+                                <button
+                                    key={option.value}
+                                    type="button"
+                                    onClick={() => applyQuickRange(option.value)}
+                                    className={`rounded-full border px-3 py-1 transition-colors ${
+                                        quickRange === option.value
+                                            ? 'border-sky-400/70 bg-sky-500/10 text-sky-200'
+                                            : 'border-slate-700 bg-slate-900/60 text-slate-300 hover:border-slate-500'
+                                    }`}
+                                >
+                                    {option.label}
+                                </button>
+                            ))}
                         </div>
-                        <div>
-                            <label className="text-sm font-medium text-slate-300">結束時間</label>
-                            <input
-                                type="datetime-local"
-                                value={endInput}
-                                onChange={event => setEndInput(event.target.value)}
-                                className="mt-1 w-full rounded-md bg-slate-900 border border-slate-700 px-3 py-2 text-sm text-slate-100"
-                            />
+
+                        <div className="grid grid-cols-1 gap-4">
+                            <div>
+                                <label className="text-sm font-medium text-slate-300">開始時間</label>
+                                <input
+                                    type="datetime-local"
+                                    value={startInput}
+                                    onChange={event => {
+                                        setQuickRange('custom');
+                                        setStartInput(event.target.value);
+                                    }}
+                                    className="mt-1 w-full rounded-md bg-slate-900 border border-slate-700 px-3 py-2 text-sm text-slate-100"
+                                />
+                            </div>
+                            <div>
+                                <label className="text-sm font-medium text-slate-300">結束時間</label>
+                                <input
+                                    type="datetime-local"
+                                    value={endInput}
+                                    onChange={event => {
+                                        setQuickRange('custom');
+                                        setEndInput(event.target.value);
+                                    }}
+                                    className="mt-1 w-full rounded-md bg-slate-900 border border-slate-700 px-3 py-2 text-sm text-slate-100"
+                                />
+                            </div>
                         </div>
                     </div>
 
@@ -453,16 +649,49 @@ const BacktestingPage: React.FC = () => {
                                         <Icon name="activity" className="w-4 h-4" />
                                         <span>觸發詳情</span>
                                     </h3>
-                                    <div className="space-y-2 max-h-48 overflow-y-auto pr-1">
+                                    <div className="space-y-2 max-h-56 overflow-y-auto pr-1">
                                         {activeRule.trigger_points.length === 0 && (
                                             <div className="text-sm text-slate-500">此規則在指定期間未觸發。</div>
                                         )}
-                                        {activeRule.trigger_points.map(point => (
-                                            <div key={`${point.timestamp}-${point.value}`} className="text-sm text-slate-300 border border-slate-800 rounded-md px-3 py-2">
-                                                <div className="font-medium">{formatDisplayTime(point.timestamp)} · 值 {point.value}</div>
-                                                <div className="text-xs text-slate-400">{point.condition_summary}</div>
-                                            </div>
-                                        ))}
+                                        {activeRule.trigger_points.map(point => {
+                                            const status = point.match_status || 'unknown';
+                                            return (
+                                                <div
+                                                    key={`${point.timestamp}-${point.value}`}
+                                                    className="border border-slate-800 rounded-md px-3 py-2 text-sm text-slate-200 bg-slate-900/40"
+                                                >
+                                                    <div className="flex items-start justify-between gap-3">
+                                                        <div>
+                                                            <div className="font-medium text-slate-100">
+                                                                {formatDisplayTime(point.timestamp)} · 值 {point.value}
+                                                            </div>
+                                                            <div className="text-xs text-slate-400">{point.condition_summary}</div>
+                                                            {point.ground_truth_event_label && (
+                                                                <div className="text-xs text-slate-500 mt-1">對應事件：{point.ground_truth_event_label}</div>
+                                                            )}
+                                                            {point.detection_delay_seconds !== null && point.detection_delay_seconds !== undefined && (
+                                                                <div className="text-xs text-slate-500">偵測延遲：{point.detection_delay_seconds} 秒</div>
+                                                            )}
+                                                        </div>
+                                                        <div className="flex flex-col items-end gap-1">
+                                                            {renderMatchBadge(status)}
+                                                            {point.tags && point.tags.length > 0 && (
+                                                                <div className="flex flex-wrap justify-end gap-1">
+                                                                    {point.tags.map(tag => (
+                                                                        <span key={tag} className="rounded bg-slate-800 px-2 py-0.5 text-[10px] text-slate-300">
+                                                                            #{tag}
+                                                                        </span>
+                                                                    ))}
+                                                                </div>
+                                                            )}
+                                                        </div>
+                                                    </div>
+                                                    {point.notes && (
+                                                        <div className="mt-2 text-xs text-slate-400">{point.notes}</div>
+                                                    )}
+                                                </div>
+                                            );
+                                        })}
                                     </div>
                                 </div>
 
@@ -490,6 +719,75 @@ const BacktestingPage: React.FC = () => {
                                             </div>
                                         ))}
                                     </div>
+                                </div>
+                            </div>
+
+                            <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+                                <div className="bg-slate-900/60 border border-slate-800 rounded-md p-4 space-y-3">
+                                    <h3 className="text-sm font-semibold text-slate-200 flex items-center space-x-2">
+                                        <Icon name="list" className="w-4 h-4" />
+                                        <span>人工標記事件對照</span>
+                                    </h3>
+                                    <div className="space-y-2 max-h-56 overflow-y-auto pr-1">
+                                        {activeRule.actual_events.length === 0 && (
+                                            <div className="text-sm text-slate-500">此期間沒有人工標記的事件。</div>
+                                        )}
+                                        {activeRule.actual_events.map(event => (
+                                            <div key={`${event.id ?? event.label}-${event.start_time}`} className="border border-slate-800 rounded-md px-3 py-2 text-sm text-slate-200 bg-slate-900/40">
+                                                <div className="flex items-start justify-between gap-3">
+                                                    <div className="space-y-1">
+                                                        <div className="font-medium text-slate-100">{event.label}</div>
+                                                        <div className="text-xs text-slate-400">
+                                                            {formatDisplayTime(event.start_time)}
+                                                            {event.end_time && ` ~ ${formatDisplayTime(event.end_time)}`}
+                                                        </div>
+                                                        {event.tags && event.tags.length > 0 && (
+                                                            <div className="flex flex-wrap gap-1">
+                                                                {event.tags.map(tag => (
+                                                                    <span key={tag} className="rounded bg-slate-800 px-2 py-0.5 text-[10px] text-slate-300">#{tag}</span>
+                                                                ))}
+                                                            </div>
+                                                        )}
+                                                        {event.detection_delay_seconds !== null && event.detection_delay_seconds !== undefined && (
+                                                            <div className="text-xs text-slate-500">偵測延遲：{event.detection_delay_seconds} 秒</div>
+                                                        )}
+                                                        {event.notes && <div className="text-xs text-slate-400">{event.notes}</div>}
+                                                    </div>
+                                                    <div className="flex flex-col items-end gap-1">
+                                                        {renderMatchBadge(event.match_status)}
+                                                        {event.matched_trigger_point_id && (
+                                                            <span className="text-[10px] text-slate-400">觸發 ID：{event.matched_trigger_point_id}</span>
+                                                        )}
+                                                    </div>
+                                                </div>
+                                            </div>
+                                        ))}
+                                    </div>
+                                </div>
+
+                                <div className="bg-slate-900/60 border border-slate-800 rounded-md p-4 space-y-3">
+                                    <h3 className="text-sm font-semibold text-slate-200 flex items-center space-x-2">
+                                        <Icon name="alert-triangle" className="w-4 h-4" />
+                                        <span>回放品質洞察</span>
+                                    </h3>
+                                    <ul className="space-y-2 text-sm text-slate-300">
+                                        <li className="flex items-start gap-2">
+                                            <span className="mt-1 h-2 w-2 rounded-full bg-emerald-400" />
+                                            <span>命中事件：{activeRule.triggered_count - activeRule.false_positive_count}</span>
+                                        </li>
+                                        <li className="flex items-start gap-2">
+                                            <span className="mt-1 h-2 w-2 rounded-full bg-rose-400" />
+                                            <span>誤報事件：{activeRule.false_positive_count}</span>
+                                        </li>
+                                        <li className="flex items-start gap-2">
+                                            <span className="mt-1 h-2 w-2 rounded-full bg-amber-400" />
+                                            <span>漏報事件：{activeRule.false_negative_count}</span>
+                                        </li>
+                                        <li className="flex items-start gap-2">
+                                            <span className="mt-1 h-2 w-2 rounded-full bg-sky-400" />
+                                            <span>人工標記總數：{activeRule.actual_events.length}</span>
+                                        </li>
+                                    </ul>
                                 </div>
                             </div>
 

--- a/types.ts
+++ b/types.ts
@@ -925,6 +925,12 @@ export interface BacktestingTimeRange {
   end_time: string;
 }
 
+export type BacktestingMatchStatus =
+  | 'true_positive'
+  | 'false_positive'
+  | 'false_negative'
+  | 'unknown';
+
 export interface BacktestingActualEvent {
   id?: string;
   label: string;
@@ -932,6 +938,11 @@ export interface BacktestingActualEvent {
   end_time?: string;
   severity?: IncidentSeverity;
   notes?: string;
+  tags?: string[];
+  match_status?: BacktestingMatchStatus;
+  matched_trigger_point_id?: string | null;
+  detection_time?: string;
+  detection_delay_seconds?: number | null;
 }
 
 export interface BacktestingTaskOptions {
@@ -968,6 +979,12 @@ export interface BacktestingTriggerPoint {
   value: number;
   condition_summary: string;
   duration_minutes?: number;
+  match_status?: BacktestingMatchStatus;
+  ground_truth_event_id?: string | null;
+  ground_truth_event_label?: string | null;
+  tags?: string[];
+  notes?: string;
+  detection_delay_seconds?: number | null;
 }
 
 export interface BacktestingRecommendation {


### PR DESCRIPTION
## Summary
- add quick time-range presets and richer chart interactions to the backtesting page
- surface ground truth comparisons with precision/recall insights in the UI
- extend schemas and API specs to capture ground truth events and match metadata

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dfa0760bf8832d8b52e26d8a994a55