### PR TITLE
feat: add dark/light aware KPI card status palette

### DIFF
--- a/components/KpiCard.css
+++ b/components/KpiCard.css
@@ -104,6 +104,9 @@
   color: var(--kpi-card-change-text, inherit);
   font-size: 11px;
   font-weight: 500;
+  background-color: var(--kpi-card-change-bg, transparent);
+  padding: 0 6px;
+  border-radius: 999px;
 }
 
 .kpi-card-change-icon {
@@ -113,9 +116,10 @@
   width: 22px;
   height: 22px;
   border-radius: 999px;
-  background: var(--kpi-card-change-icon-bg, rgb(255, 255, 255));
+  background: var(--kpi-card-change-icon-bg, transparent);
   color: var(--kpi-card-change-icon-color, inherit);
   font-size: 12px;
+  text-shadow: var(--kpi-card-change-icon-shadow, none);
 }
 
 .tone-swatch {

--- a/pages/settings/platform/LayoutSettingsPage.tsx
+++ b/pages/settings/platform/LayoutSettingsPage.tsx
@@ -9,6 +9,7 @@ import { useContent } from '../../../contexts/ContentContext';
 import StatusTag from '../../../components/StatusTag';
 import { formatTimestamp } from '../../../utils/time';
 import KpiCard, { getKpiCardPalette } from '../../../components/KpiCard';
+import { useTheme } from '../../../contexts/ThemeContext';
 
 interface ListItemProps {
     widget: LayoutWidget;
@@ -425,11 +426,12 @@ const LayoutSettingsPage: React.FC = () => {
     const pageContent = content?.LAYOUT_SETTINGS;
     const globalContent = content?.GLOBAL;
     const { token } = theme.useToken();
+    const { theme: themeMode } = useTheme();
     const colorLabelOverrides = (pageContent?.KPI_CARD_COLOR_LABELS as Partial<Record<KpiCardColor, string>> | undefined) ?? undefined;
     const kpiColorOptions = useMemo(() => {
         const tones: KpiCardColor[] = ['default', 'primary', 'success', 'warning', 'error', 'info', 'performance', 'resource', 'health', 'monitoring'];
         return tones.map((tone) => {
-            const palette = getKpiCardPalette(token, tone);
+            const palette = getKpiCardPalette(token, tone, { themeMode });
             const labelText = colorLabelOverrides?.[tone] ?? KPI_CARD_COLOR_LABELS[tone];
             return {
                 label: (
@@ -449,7 +451,7 @@ const LayoutSettingsPage: React.FC = () => {
                 value: tone,
             };
         });
-    }, [colorLabelOverrides, token]);
+    }, [colorLabelOverrides, themeMode, token]);
 
     const fetchData = useCallback(async () => {
         setIsLoading(true);


### PR DESCRIPTION
## Summary
- introduce reusable Grafana-inspired KPI status palettes for dark and light themes
- update KPI card trend indicator styling to avoid color collisions and improve contrast
- surface theme-aware palette previews in layout settings using the new color tokens

## Testing
- npm run build *(fails: optional @rollup/rollup-linux-x64-gnu dependency missing in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e193bb7ff4832d9598e23d727e46c1